### PR TITLE
Updates for hudson-test-harness

### DIFF
--- a/hudson-core/src/main/java/hudson/ExtensionList.java
+++ b/hudson-core/src/main/java/hudson/ExtensionList.java
@@ -232,7 +232,7 @@ public class ExtensionList<T> extends AbstractList<T> {
      */
     protected List<ExtensionComponent<T>> load() {
         if (LOGGER.isLoggable(Level.FINE))
-            LOGGER.log(Level.FINE,"Loading ExtensionList: "+extensionType, new Throwable());
+            LOGGER.log(Level.FINE,"Loading ExtensionList: "+extensionType);
 
         return hudson.getPluginManager().getPluginStrategy().findComponents(extensionType, hudson);
     }

--- a/hudson-inject/pom.xml
+++ b/hudson-inject/pom.xml
@@ -103,6 +103,18 @@ THE SOFTWARE.
           <forkMode>always</forkMode>
         </configuration>
       </plugin>
+
+     <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/hudson-inject/src/main/aspect/org/hudsonci/inject/injecto/internal/InjectomaticAspect.aj
+++ b/hudson-inject/src/main/aspect/org/hudsonci/inject/injecto/internal/InjectomaticAspect.aj
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * </ul>
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 public privileged aspect InjectomaticAspect
 {

--- a/hudson-inject/src/main/java/org/hudsonci/inject/Priority.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/Priority.java
@@ -34,7 +34,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Allows components to be adorned with an optional priority.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 @Target(TYPE)
 @Retention(RUNTIME)

--- a/hudson-inject/src/main/java/org/hudsonci/inject/Smoothie.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/Smoothie.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * Smoothie container access.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 public class Smoothie
 {

--- a/hudson-inject/src/main/java/org/hudsonci/inject/Smoothie.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/Smoothie.java
@@ -24,7 +24,6 @@
 
 package org.hudsonci.inject;
 
-import hudson.Extension;
 import org.hudsonci.inject.internal.SmoothieContainerBootstrap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,27 +70,5 @@ public class Smoothie
             return new SmoothieContainerBootstrap().bootstrap();
         }
         return container;
-    }
-
-    /**
-     * Determine the priority of the given component.
-     */
-    public static <T> double priorityOf(final T component) {
-        assert component != null;
-
-        Class<?> type = component.getClass();
-        double value = 0;
-        Priority priority = type.getAnnotation(Priority.class);
-        if (priority != null) {
-            value = priority.value();
-        }
-        else {
-            Extension ext = type.getAnnotation(Extension.class);
-            if (ext != null) {
-                value = ext.ordinal();
-            }
-        }
-
-        return value;
     }
 }

--- a/hudson-inject/src/main/java/org/hudsonci/inject/SmoothieContainer.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/SmoothieContainer.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Annotation;
  * Smoothie container.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 public interface SmoothieContainer
 {

--- a/hudson-inject/src/main/java/org/hudsonci/inject/injecto/Injectable.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/injecto/Injectable.java
@@ -28,7 +28,7 @@ package org.hudsonci.inject.injecto;
  * Marker interface which allows any object to get post-construction injection magically.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 public interface Injectable
 {

--- a/hudson-inject/src/main/java/org/hudsonci/inject/injecto/Injectomatic.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/injecto/Injectomatic.java
@@ -31,7 +31,7 @@ import org.hudsonci.inject.injecto.internal.InjectomaticImpl;
  * Magically injection system.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 @ImplementedBy(InjectomaticImpl.class)
 public interface Injectomatic

--- a/hudson-inject/src/main/java/org/hudsonci/inject/injecto/InjectomaticAware.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/injecto/InjectomaticAware.java
@@ -28,7 +28,7 @@ package org.hudsonci.inject.injecto;
  * Allows any object to become aware of the {@link Injectomatic} component w/o having to be injectable itself.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 public interface InjectomaticAware
 {

--- a/hudson-inject/src/main/java/org/hudsonci/inject/injecto/internal/InjectomaticAspectHelper.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/injecto/internal/InjectomaticAspectHelper.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * Helper for the {@link Injectomatic} aspect.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 public class InjectomaticAspectHelper
 {

--- a/hudson-inject/src/main/java/org/hudsonci/inject/injecto/internal/InjectomaticImpl.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/injecto/internal/InjectomaticImpl.java
@@ -46,7 +46,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Default {@link org.hudsonci.inject.injecto.Injectomatic} implementation.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 @Named
 @Singleton

--- a/hudson-inject/src/main/java/org/hudsonci/inject/injecto/internal/RegisteredTypeInstaller.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/injecto/internal/RegisteredTypeInstaller.java
@@ -36,7 +36,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Helper to register injectable types for Hudson when the container starts.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 @Named
 @EagerSingleton

--- a/hudson-inject/src/main/java/org/hudsonci/inject/injecto/internal/XStreamInjectoHandler.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/injecto/internal/XStreamInjectoHandler.java
@@ -50,7 +50,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Handles {@link Injectomatic} muck when unmarshalling components via XStream.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 @Named
 @EagerSingleton

--- a/hudson-inject/src/main/java/org/hudsonci/inject/injecto/internal/package-info.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/injecto/internal/package-info.java
@@ -25,6 +25,6 @@
 /**
  * Magically injection internals.
  *
- * @since 1.396
+ * @since 1.397
  */
 package org.hudsonci.inject.injecto.internal;

--- a/hudson-inject/src/main/java/org/hudsonci/inject/injecto/package-info.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/injecto/package-info.java
@@ -25,6 +25,6 @@
 /**
  * Magically injection system.
  *
- * @since 1.396
+ * @since 1.397
  */
 package org.hudsonci.inject.injecto;

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/ClassSpaceFactory.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/ClassSpaceFactory.java
@@ -37,7 +37,7 @@ import java.util.List;
  * Helper to build {@link ClassSpace} instances.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 public class ClassSpaceFactory
 {

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/HudsonModule.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/HudsonModule.java
@@ -42,7 +42,7 @@ import javax.inject.Named;
  * Configuration of bindings for Hudson components.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 public class HudsonModule
     extends AbstractModule

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/OID.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/OID.java
@@ -40,7 +40,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * the {@link System#identityHashCode}.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 @XStreamAlias("oid")
 public class OID

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/SmoothieContainerBootstrap.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/SmoothieContainerBootstrap.java
@@ -37,7 +37,7 @@ import org.sonatype.guice.bean.reflect.ClassSpace;
  * Bootstraps the container.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 public class SmoothieContainerBootstrap
 {

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/SmoothieContainerImpl.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/SmoothieContainerImpl.java
@@ -58,7 +58,7 @@ import java.util.Map;
  * {@link SmoothieContainer} implementation.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 public class SmoothieContainerImpl
     implements SmoothieContainer
@@ -92,7 +92,7 @@ public class SmoothieContainerImpl
     /**
      * Not officially part of {@link SmoothieContainer} API, exposed for {@link org.hudsonci.inject.injecto.Injectomatic}.
      *
-     * @since 1.396
+     * @since 1.397
      */
     public Injector rootInjector() {
         return root;

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/SmoothieContainerImpl.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/SmoothieContainerImpl.java
@@ -145,6 +145,9 @@ public class SmoothieContainerImpl
         }
     }
 
+    // FIXME: Bootstrap probably needs to be aware of WEB-INF/lib/* bits, and should include its own ExtensionModule?
+
+
     /**
      * Bindings and class space for plugins.
      */
@@ -161,6 +164,8 @@ public class SmoothieContainerImpl
         @Override
         protected void configure() {
             ClassSpace space = createClassSpace();
+            // FIXME: Use this here instead:
+            //install(new ExtensionModule(space));
             install(new SpaceModule(space));
             install(new SezPozExtensionModule(space));
             super.configure();

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/ExtensionLocator.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/ExtensionLocator.java
@@ -31,7 +31,7 @@ import java.util.List;
 /**
  * Allows {@link hudson.PluginStrategy} complete control over how extensions are found.
  *
- * @since 1.396
+ * @since 1.397
  */
 public interface ExtensionLocator
 {

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/ExtensionModule.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/ExtensionModule.java
@@ -23,7 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Configures modules to discover Hudson components.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 public final class ExtensionModule
     implements Module

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/SezPozExtensionModule.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/SezPozExtensionModule.java
@@ -38,7 +38,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Guice {@link Module} that binds types based on SezPoz index.
  *
- * @since 1.396
+ * @since 1.397
  */
 @SuppressWarnings( { "unchecked", "rawtypes" } )
 public final class SezPozExtensionModule

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/SmoothieComponent.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/SmoothieComponent.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Annotation;
  * Smoothie component extension holder.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 public class SmoothieComponent<T>
     extends ExtensionComponent<T>

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/SmoothieExtensionLocator.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/SmoothieExtensionLocator.java
@@ -44,7 +44,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Smoothie {@link ExtensionLocator}.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 @Named
 @Singleton

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/package-info.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/package-info.java
@@ -25,6 +25,6 @@
 /**
  * Provides injection support for Hudson extensions.
  *
- * @since 1.396
+ * @since 1.397
  */
 package org.hudsonci.inject.internal.extension;

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/package-info.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/package-info.java
@@ -25,6 +25,6 @@
 /**
  * Internal support for the Hudson injection system.
  *
- * @since 1.396
+ * @since 1.397
  */
 package org.hudsonci.inject.internal;

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/plugin/DelegatingPluginStrategy.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/plugin/DelegatingPluginStrategy.java
@@ -44,7 +44,7 @@ import java.util.List;
  * Delegates to {@link PluginStrategy} implementation bound in Guice context.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 public class DelegatingPluginStrategy
     implements PluginStrategy

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/plugin/PluginClassLoader.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/plugin/PluginClassLoader.java
@@ -36,7 +36,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Plugin class-loader.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 public class PluginClassLoader
     extends URLClassLoader

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/plugin/PluginWrapperFactory.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/plugin/PluginWrapperFactory.java
@@ -47,7 +47,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Provides {@link PluginWrapper} creation facilities.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 @Named
 @Singleton

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/plugin/SmoothiePluginStrategy.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/plugin/SmoothiePluginStrategy.java
@@ -50,7 +50,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Smoothie {@link PluginStrategy}.
  *
  * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
- * @since 1.396
+ * @since 1.397
  */
 @Named("default")
 @Singleton

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/plugin/package-info.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/plugin/package-info.java
@@ -25,6 +25,6 @@
 /**
  * Provides injection support for Hudson plugins.
  *
- * @since 1.396
+ * @since 1.397
  */
 package org.hudsonci.inject.internal.plugin;

--- a/hudson-inject/src/main/java/org/hudsonci/inject/package-info.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/package-info.java
@@ -27,6 +27,6 @@
  *
  * What is Smoothie?  Smoothie is a blend of Guice and Hudson... a yummy treat.
  *
- * @since 1.396
+ * @since 1.397
  */
 package org.hudsonci.inject;

--- a/hudson-inject/src/test/java/org/hudsonci/inject/SmoothieUtil.java
+++ b/hudson-inject/src/test/java/org/hudsonci/inject/SmoothieUtil.java
@@ -39,7 +39,7 @@ public class SmoothieUtil
 {
     private static final Logger log = LoggerFactory.getLogger(SmoothieUtil.class);
 
-    public static void setField(Class type, String name, Object instance, Object value) throws NoSuchFieldException, IllegalAccessException {
+    private static void setField(Class type, String name, Object instance, Object value) throws NoSuchFieldException, IllegalAccessException {
         Field field = type.getDeclaredField(name);
         field.setAccessible(true);
         field.set(instance, value);

--- a/hudson-inject/src/test/java/org/hudsonci/inject/SmoothieUtil.java
+++ b/hudson-inject/src/test/java/org/hudsonci/inject/SmoothieUtil.java
@@ -24,6 +24,7 @@
 
 package org.hudsonci.inject;
 
+import org.hudsonci.inject.injecto.internal.InjectomaticAspectHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,20 +39,34 @@ public class SmoothieUtil
 {
     private static final Logger log = LoggerFactory.getLogger(SmoothieUtil.class);
 
+    public static void setField(Class type, String name, Object instance, Object value) throws NoSuchFieldException, IllegalAccessException {
+        Field field = type.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(instance, value);
+    }
+
     /**
      * Uses reflection to install a container instance.  This allows the container instance to be reset.
      *
      * @param container     The container to install in {@link Smoothie} or null to reset to the default.
      */
     public static void installContainer(final SmoothieContainer container) throws NoSuchFieldException, IllegalAccessException {
-        Field field = Smoothie.class.getDeclaredField("container");
-        field.setAccessible(true);
-        field.set(null, container);
+        setField(Smoothie.class, "container", null, null);
         if (container == null) {
             log.info("Reset container");
         }
         else {
             log.info("Installed custom container: {}", container);
         }
+        resetInjectomaticAspectHelper();
+    }
+
+    private static void resetInjectomaticAspectHelper() throws NoSuchFieldException, IllegalAccessException {
+        setField(InjectomaticAspectHelper.class, "injecto", null, null);
+        log.info("Reset Injectomatic aspect helper");
+    }
+
+    public static void reset() throws NoSuchFieldException, IllegalAccessException {
+        installContainer(null);
     }
 }

--- a/hudson-inject/src/test/java/org/hudsonci/inject/TestSupport.java
+++ b/hudson-inject/src/test/java/org/hudsonci/inject/TestSupport.java
@@ -53,6 +53,6 @@ public abstract class TestSupport
 
     @After
     public void tearDown() throws Exception {
-        SmoothieUtil.installContainer(null);
+        SmoothieUtil.reset();
     }
 }

--- a/hudson-test-harness/pom.xml
+++ b/hudson-test-harness/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
   <groupId>org.jvnet.hudson.main</groupId>
   <artifactId>hudson-test-harness</artifactId>
   <packaging>stapler-jar</packaging>
-  <name>Hudson :: Plugin Test Harness</name>
+  <name>Hudson :: Test Harness</name>
   <description>
     Unit test harness (src/main) and Unit tests for Hudson core (src/test)
   </description>
@@ -211,11 +211,11 @@ THE SOFTWARE.
       <artifactId>htmlunit</artifactId>
       <version>2.6-hudson-2</version>
       <exclusions>
-      	<exclusion>
-	      	<!--  hides JDK DOM classes in Eclipse -->
-      		<groupId>xml-apis</groupId>
-      		<artifactId>xml-apis</artifactId>
-      	</exclusion>
+        <exclusion>
+          <!--  hides JDK DOM classes in Eclipse -->
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/hudson-test-harness/pom.xml
+++ b/hudson-test-harness/pom.xml
@@ -48,52 +48,62 @@ THE SOFTWARE.
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+            <systemPropertyVariables>
+                <java.awt.headless>true</java.awt.headless>
+                <java.util.logging.config.file>${project.basedir}/target/test-classes/jul.properties</java.util.logging.config.file>
+                <buildDirectory>${project.build.directory}</buildDirectory>
+                <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+            </systemPropertyVariables>
             <!--
           <skip>true</skip>
           -->
           <!-- tests now run by maven-junit-plugin -->
         </configuration>
       </plugin>
-      <plugin>
-        <!-- see http://maven-junit-plugin.kenai.com/ for more info -->
-        <groupId>com.sun.maven</groupId>
-        <artifactId>maven-junit-plugin</artifactId>
-        <version>1.6</version>
-        <configuration>
-          <skipTests>true</skipTests>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <configuration>
-              <fork>true</fork>
-              <concurrency>${concurrency}</concurrency>
-              <argLine>-XX:MaxPermSize=192m -Xmx256m -Dfile.encoding=UTF-8</argLine>
-              <systemProperties>
-                <property>
-                  <!-- use AntClassLoader that supports predictable file handle release -->
-                  <name>hudson.ClassicPluginStrategy.useAntClassLoader</name>
-                  <value>true</value>
-                </property>
-                <property>
-                  <name>hudson.maven.debug</name>
-                  <value>${mavenDebug}</value>
-                </property>
-                <property>
-                  <name>java.io.tmpdir</name>
-                  <value>${project.build.directory}</value>
-                </property> 
-                <property>
-                  <name>buildDirectory</name>
-                  <value>${project.build.directory}</value>
-                </property>                               
-              </systemProperties>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+      <!--<plugin>-->
+        <!--&lt;!&ndash; see http://maven-junit-plugin.kenai.com/ for more info &ndash;&gt;-->
+        <!--<groupId>com.sun.maven</groupId>-->
+        <!--<artifactId>maven-junit-plugin</artifactId>-->
+        <!--<version>1.6</version>-->
+        <!--<configuration>-->
+          <!--<skipTests>true</skipTests>-->
+        <!--</configuration>-->
+        <!--<executions>-->
+          <!--<execution>-->
+            <!--<goals>-->
+              <!--<goal>test</goal>-->
+            <!--</goals>-->
+            <!--<configuration>-->
+              <!--<fork>true</fork>-->
+              <!--<concurrency>${concurrency}</concurrency>-->
+              <!--<argLine>-XX:MaxPermSize=192m -Xmx256m -Dfile.encoding=UTF-8</argLine>-->
+              <!--<systemProperties>-->
+                <!--<property>-->
+                  <!--&lt;!&ndash; use AntClassLoader that supports predictable file handle release &ndash;&gt;-->
+                  <!--<name>hudson.ClassicPluginStrategy.useAntClassLoader</name>-->
+                  <!--<value>true</value>-->
+                <!--</property>-->
+                <!--<property>-->
+                  <!--<name>java.util.logging.config.file</name>-->
+                  <!--<value>${basedir}/target/test-classes/jul.properties</value>-->
+                <!--</property>-->
+                <!--<property>-->
+                  <!--<name>hudson.maven.debug</name>-->
+                  <!--<value>${mavenDebug}</value>-->
+                <!--</property>-->
+                <!--<property>-->
+                  <!--<name>java.io.tmpdir</name>-->
+                  <!--<value>${project.build.directory}</value>-->
+                <!--</property> -->
+                <!--<property>-->
+                  <!--<name>buildDirectory</name>-->
+                  <!--<value>${project.build.directory}</value>-->
+                <!--</property>                               -->
+              <!--</systemProperties>-->
+            <!--</configuration>-->
+          <!--</execution>-->
+        <!--</executions>-->
+      <!--</plugin>-->
       <plugin>
         <groupId>org.kohsuke.gmaven</groupId>
         <artifactId>gmaven-plugin</artifactId>
@@ -140,18 +150,31 @@ THE SOFTWARE.
         put hudson.war in the classpath. we can't pull in the war artifact directly
         because Maven excludes all wars from classpath automatically. so we need a jar artifact.
       -->
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.jvnet.hudson.main</groupId>
       <artifactId>hudson-war</artifactId>
       <version>${project.version}</version>
       <classifier>war-for-test</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-jdk14</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.jvnet.hudson.main</groupId>
+      <artifactId>hudson-inject</artifactId>
+      <classifier>tests</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jvnet.hudson.main</groupId>
       <artifactId>maven-plugin</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
+      <groupId>org.jvnet.hudson.main</groupId>
       <artifactId>hudson-cli</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -204,6 +227,16 @@ THE SOFTWARE.
       <groupId>org.jvnet.hudson</groupId>
       <artifactId>netx</artifactId>
       <version>0.5-hudson-2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/hudson-test-harness/pom.xml
+++ b/hudson-test-harness/pom.xml
@@ -50,7 +50,7 @@ THE SOFTWARE.
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
             <workingDirectory>${project.build.directory}</workingDirectory>
-            <forkMode>once</forkMode>
+            <forkMode>always</forkMode>
             <argLine>-ea -XX:MaxPermSize=192m -Xmx256m</argLine>
             <systemPropertyVariables>
                 <file.encoding>UTF-8</file.encoding>

--- a/hudson-test-harness/pom.xml
+++ b/hudson-test-harness/pom.xml
@@ -49,8 +49,9 @@ THE SOFTWARE.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+            <workingDirectory>${project.build.directory}</workingDirectory>
             <forkMode>once</forkMode>
-            <argLine>-XX:MaxPermSize=192m -Xmx256m</argLine>
+            <argLine>-ea -XX:MaxPermSize=192m -Xmx256m</argLine>
             <systemPropertyVariables>
                 <file.encoding>UTF-8</file.encoding>
                 <java.awt.headless>true</java.awt.headless>

--- a/hudson-test-harness/pom.xml
+++ b/hudson-test-harness/pom.xml
@@ -46,20 +46,20 @@ THE SOFTWARE.
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+            <argLine>-XX:MaxPermSize=192m -Xmx256m</argLine>
             <systemPropertyVariables>
+                <file.encoding>UTF-8</file.encoding>
                 <java.awt.headless>true</java.awt.headless>
                 <java.util.logging.config.file>${project.basedir}/target/test-classes/jul.properties</java.util.logging.config.file>
                 <buildDirectory>${project.build.directory}</buildDirectory>
                 <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             </systemPropertyVariables>
-            <!--
-          <skip>true</skip>
-          -->
-          <!-- tests now run by maven-junit-plugin -->
         </configuration>
       </plugin>
+
       <!--<plugin>-->
         <!--&lt;!&ndash; see http://maven-junit-plugin.kenai.com/ for more info &ndash;&gt;-->
         <!--<groupId>com.sun.maven</groupId>-->

--- a/hudson-test-harness/pom.xml
+++ b/hudson-test-harness/pom.xml
@@ -49,6 +49,7 @@ THE SOFTWARE.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+            <forkMode>once</forkMode>
             <argLine>-XX:MaxPermSize=192m -Xmx256m</argLine>
             <systemPropertyVariables>
                 <file.encoding>UTF-8</file.encoding>
@@ -56,6 +57,7 @@ THE SOFTWARE.
                 <java.util.logging.config.file>${project.basedir}/target/test-classes/jul.properties</java.util.logging.config.file>
                 <buildDirectory>${project.build.directory}</buildDirectory>
                 <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+                <hudson.maven.debug>${mavenDebug}</hudson.maven.debug>
             </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/hudson-test-harness/src/test/resources/jul.properties
+++ b/hudson-test-harness/src/test/resources/jul.properties
@@ -1,0 +1,20 @@
+#
+# Sonatype Hudson Professional (tm)
+# Copyright (c) 2010-2011 Sonatype, Inc. All rights reserved.
+# Includes the third-party code listed at http://www.sonatype.com/products/hudson/attributions/.
+# "Sonatype" and "Sonatype Hudson Professional" are trademarks of Sonatype, Inc.
+# "Hudson" is a trademark of Oracle, Inc.
+#
+
+# Install the JUL -> SLF4J bridge
+handlers=org.slf4j.bridge.SLF4JBridgeHandler
+
+# FINEST  -> TRACE
+# FINER   -> DEBUG
+# FINE    -> DEBUG
+# INFO    -> INFO
+# WARNING -> WARN
+# SEVER   -> ERROR
+
+# Set the root logger level
+.level=INFO

--- a/hudson-test-harness/src/test/resources/logback-test.xml
+++ b/hudson-test-harness/src/test/resources/logback-test.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The MIT License
+
+    Copyright (c) 2010-2011 Sonatype, Inc. All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+-->
+
+<configuration>
+
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.out</target>
+        <encoder>
+            <pattern>%date %level [%thread%X{DC}] %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="hudson" level="DEBUG"/>
+    <logger name="org.hudsonci.inject" level="DEBUG"/>
+    <logger name="org.jvnet.hudson" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ THE SOFTWARE.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.7.1</version>
+          <version>2.7.2</version>
           <configuration>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -536,6 +536,7 @@ THE SOFTWARE.
       </reporting>
     </profile>
     <profile>
+      <!-- FIXME: This is crappy use of a default activated profile. -->
       <id>debug</id>
       <activation>
         <activeByDefault>true</activeByDefault>

--- a/pom.xml
+++ b/pom.xml
@@ -470,6 +470,13 @@ THE SOFTWARE.
 
       <dependency>
         <groupId>org.jvnet.hudson.main</groupId>
+        <artifactId>hudson-inject</artifactId>
+        <classifier>tests</classifier>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jvnet.hudson.main</groupId>
         <artifactId>hudson-remoting</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -627,6 +634,18 @@ THE SOFTWARE.
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <profile>
+      <id>integration-tests</id>
+      <activation>
+        <property>
+            <name>it</name>
+        </property>
+      </activation>
+      <modules>
+        <module>hudson-test-harness</module>
+      </modules>
     </profile>
   </profiles>
   


### PR DESCRIPTION
A bunch of fixes for hudson-test-harness to work better with smoothie.  Some tests are still failing, need to investigate more.  Tests will run slower for now.  The smoothie stuff was never designed to be used as the hudson-test-harness' TestPluginManager wants them.  So I'm forcing everything to use the LocalPluginManager for now.  Will look at improving the performance later, though IIRC this was always slow, so I'm not sure how much slower use of the LocalPluginManager is making things.

Added hudson-test-harness into a profile so you can:

mvn -Dit -Pdebug

The -Pdebug is required to build, its an active by default profile (which should be removed) which won't activate if another profile is activated.
