### PR TITLE
Untitled

### DIFF
--- a/hudson-remoting/src/test/java/hudson/remoting/PipeClosedBugTest.java
+++ b/hudson-remoting/src/test/java/hudson/remoting/PipeClosedBugTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  * 
- * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ * Copyright (c) 2011-, Winston Prakas, Oracle Corporation
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/hudson-remoting/src/test/java/hudson/remoting/PipeClosedBugTest.java
+++ b/hudson-remoting/src/test/java/hudson/remoting/PipeClosedBugTest.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.remoting;
+
+import java.io.OutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Test for "http://issues.hudson-ci.org/browse/HUDSON-7809"
+ * 
+ * @author Winston Prakash
+ */
+public class PipeClosedBugTest extends RmiTestBase implements Serializable {
+
+    public void testRemoteWrite() throws Exception {
+        final Pipe pipe = Pipe.createRemoteToLocal();
+        Future<Integer> f = channel.callAsync(new WritingCallable(pipe));
+
+        readFromPipe(pipe);
+
+        int r = f.get();
+        assertEquals(5, r);
+    }
+
+    private void readFromPipe(Pipe p) throws IOException {
+        System.out.println("South: Reading only one byte from pipe and closing stream.");
+        InputStream in = p.getIn();
+        // Read only one byte from pipe and close, even through the writer continues
+        // to write more bytes in to the pipe.
+        in.read();
+        in.close();
+    }
+
+    private static class WritingCallable implements Callable<Integer, IOException> {
+
+        private final Pipe pipe;
+
+        public WritingCallable(Pipe pipe) {
+            this.pipe = pipe;
+        }
+
+        public Integer call() throws IOException {
+            writeToPipe(pipe);
+            return 5;
+        }
+
+        private void writeToPipe(Pipe pipe) {
+            System.out.println("North: Writing several bytes of data to pipe.");
+            try {
+                OutputStream os = pipe.getOut();
+                byte[] buf = new byte[384];
+                for (int i = 0; i < 256; i++) {
+                    Arrays.fill(buf, (byte) i);
+                    os.write(buf, 0, 256);
+                }
+                os.close();
+            } catch (IOException ex) {
+                fail("No IOException (Pipe is already closed) Expected.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is fix for dreaded  "java.io.IOException: Pipe is already closed". This fix would help several issues.

http://issues.hudson-ci.org/browse/HUDSON-7809
http://issues.hudson-ci.org/browse/HUDSON-7836
http://issues.hudson-ci.org/browse/HUDSON-7871
http://issues.hudson-ci.org/browse/HUDSON-7664
http://issues.hudson-ci.org/browse/HUDSON-7586
http://issues.hudson-ci.org/browse/HUDSON-8064

This fix plugs the symptoms. I'm still exploring the following

```
* Why the receiving side of the channel died? This may be hard to say, there could be several reason.
* Should the receiver actually sends a closing event to sender?
* Should the receiver acknowledge the receipt of closing event?
* Should the receiver keep accepting until sender acknowledge the receipt of closing event?
* What if the receiver simply died with out sending closing event?
* Should the sender assumes the receiver died if it gets exception when it sends bytes and destroy the pipe
```
