### PR TITLE
More fixes for http://issues.hudson-ci.org/browse/HUDSON-7809

### DIFF
--- a/hudson-core/src/main/java/hudson/Launcher.java
+++ b/hudson-core/src/main/java/hudson/Launcher.java
@@ -71,7 +71,8 @@ import static org.apache.commons.io.output.NullOutputStream.NULL_OUTPUT_STREAM;
  * {@link Launcher} is responsible for inheriting environment variables.
  *
  *
- * @author Kohsuke Kawaguchi
+ * @author Kohsuke Kawaguchi, Winston Prakash (bug fixes)
+ *
  * @see FilePath#createLauncher(TaskListener) 
  */
 public abstract class Launcher {
@@ -795,6 +796,18 @@ public abstract class Launcher {
                 return p.join();
             } catch (InterruptedException e) {
                 return -1;
+            } finally{
+                try {
+                    // Fix: http://issues.hudson-ci.org/browse/HUDSON-7809
+                    // This call should not return immediately after the
+                    // process is done. The pipe associated with the channel
+                    // may be still transmitting data.
+                    // Get the channel associated with this thread and flush
+                    // its IO pipe
+                    Channel.current().flushPipe();
+                } catch (InterruptedException ex) {
+                    Logger.getLogger(Launcher.class.getName()).log(Level.SEVERE, null, ex);
+                }
             }
         }
 


### PR DESCRIPTION
My earlier fix to drain the pipe before closing the receiver end of the pipe only plugs the symptoms, does not actually fix the issue.

This fix is more for the actual  cause of the symptom. I was investigating, what could causes the receiver to close earlier than writer. I'm looking at one of exception at HUDSON-7664 linked from HUDSON-7809

Caused by: hudson.remoting.FastPipedInputStream$ClosedBy: The pipe was closed at...
at hudson.remoting.FastPipedInputStream.close(FastPipedInputStream.java:112)
at sun.nio.cs.StreamDecoder.implClose(StreamDecoder.java:358)
at sun.nio.cs.StreamDecoder.close(StreamDecoder.java:173)
at java.io.InputStreamReader.close(InputStreamReader.java:182)
at java.io.BufferedReader.close(BufferedReader.java:497)
at com.tek42.perforce.parse.AbstractPerforceTemplate.saveToPerforce(AbstractPerforceTemplate.java:222)
at com.tek42.perforce.parse.Workspaces.saveWorkspace(Workspaces.java:68)
at hudson.plugins.perforce.PerforceSCM.saveWorkspaceIfDirty(PerforceSCM.java:1162)

Looking at the code of perforce plugin, HudsonP4ExecutorFactory using Hudson RemoteLauncher to execute some of the perforce command line. If a read/write Pipe is initiated in this process the remote launcher does not seem to flush the Channel Pipe before it quits.

I put some fix to flush both ends of the pipe of a channel when the channel is associated with a remote launcher before the launcher exits.
