### PR TITLE
JDK download label

### DIFF
--- a/hudson-core/src/main/resources/hudson/tools/Messages.properties
+++ b/hudson-core/src/main/resources/hudson/tools/Messages.properties
@@ -31,6 +31,6 @@ ZipExtractionInstaller.bad_connection=Server rejected connection.
 ZipExtractionInstaller.malformed_url=Malformed URL.
 ZipExtractionInstaller.could_not_connect=Could not connect to URL.
 InstallSourceProperty.DescriptorImpl.displayName=Install automatically
-JDKInstaller.DescriptorImpl.displayName=Install from java.sun.com
+JDKInstaller.DescriptorImpl.displayName=Install from Oracle
 JDKInstaller.DescriptorImpl.doCheckId=Define JDK ID
 JDKInstaller.DescriptorImpl.doCheckAcceptLicense=You must agree to the license to download the JDK.

--- a/hudson-core/src/main/resources/hudson/tools/Messages_da.properties
+++ b/hudson-core/src/main/resources/hudson/tools/Messages_da.properties
@@ -31,6 +31,6 @@ JDKInstaller.DescriptorImpl.doCheckAcceptLicense=Du skal acceptere licensen for 
 CommandInstaller.no_command=Der skal angives en kommando der skal k\u00f8res.
 ZipExtractionInstaller.malformed_url=Vanskabt URL
 CommandInstaller.no_toolHome=Der skal angives et v\u00e6rkt\u00f8jshjemmedirektorie
-JDKInstaller.DescriptorImpl.displayName=Installer fra java.sun.com
+JDKInstaller.DescriptorImpl.displayName=Installer fra Oracle
 JDKInstaller.FailedToInstallJDK=Kunne ikke installere JDK. Exit kode={0}
 JDKInstaller.DescriptorImpl.doCheckId=Definer JDK ID

--- a/hudson-core/src/main/resources/hudson/tools/Messages_de.properties
+++ b/hudson-core/src/main/resources/hudson/tools/Messages_de.properties
@@ -21,16 +21,16 @@
 # THE SOFTWARE.
 
 ToolLocationNodeProperty.displayName=Verzeichnisse von Hilfsprogrammen anpassen
-CommandInstaller.DescriptorImpl.displayName=Kommando ausführen
+CommandInstaller.DescriptorImpl.displayName=Kommando ausfï¿½hren
 CommandInstaller.no_command=Ein Kommando muss angegeben werden.
-CommandInstaller.no_toolHome=Ein Stammverzeichnis muß angegeben werden.
+CommandInstaller.no_toolHome=Ein Stammverzeichnis muï¿½ angegeben werden.
 ZipExtractionInstaller.DescriptorImpl.displayName=Entpacke *.zip/*.tar.gz-Archiv
 ZipExtractionInstaller.bad_connection=Der Server verweigerte den Verbindungsaufbau
-ZipExtractionInstaller.malformed_url=Ungültige URL
+ZipExtractionInstaller.malformed_url=Ungï¿½ltige URL
 ZipExtractionInstaller.could_not_connect=URL konnte nicht kontaktiert werden.
 InstallSourceProperty.DescriptorImpl.displayName=Automatisch installieren
-JDKInstaller.DescriptorImpl.displayName=Installiere von java.sun.com
+JDKInstaller.DescriptorImpl.displayName=Installiere von Oracle
 JDKInstaller.DescriptorImpl.doCheckId=JDK-ID definieren
-JDKInstaller.DescriptorImpl.doCheckAcceptLicense=Sie müssen der Lizenzvereinbarung zustimmen, um das JDK herunterzuladen.
+JDKInstaller.DescriptorImpl.doCheckAcceptLicense=Sie mï¿½ssen der Lizenzvereinbarung zustimmen, um das JDK herunterzuladen.
 JDKInstaller.FailedToInstallJDK=JDK konnte nicht installiert werden.
 JDKInstaller.UnableToInstallUntilLicenseAccepted=JDK kann nicht automatisch installiert werden, solange die Lizenzvereinbarung nicht akzeptiert wurde. 

--- a/hudson-core/src/main/resources/hudson/tools/Messages_es.properties
+++ b/hudson-core/src/main/resources/hudson/tools/Messages_es.properties
@@ -20,17 +20,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-ToolLocationNodeProperty.displayName=Localización de herramientas
+ToolLocationNodeProperty.displayName=Localizaciï¿½n de herramientas
 CommandInstaller.DescriptorImpl.displayName=Ejecutar comando 
 CommandInstaller.no_command=Debes especificar el comando para ejecutar.
 CommandInstaller.no_toolHome=Debes especificar el directorio raiz de la herramienta.
 JDKInstaller.FailedToInstallJDK=Fallo al installar el JDK
 JDKInstaller.UnableToInstallUntilLicenseAccepted=No se puede instalar el JDK hasta que se acepte la licencia de uso.
 ZipExtractionInstaller.DescriptorImpl.displayName=Extraer *.zip/*.tar.gz
-ZipExtractionInstaller.bad_connection=El servidor rechazó la conexión
-ZipExtractionInstaller.malformed_url=Dirección web incorrecta.
-ZipExtractionInstaller.could_not_connect=No se puede conectar a la dirección
-InstallSourceProperty.DescriptorImpl.displayName=Instalar automáticamente
-JDKInstaller.DescriptorImpl.displayName=Instalar desde java.sun.com
+ZipExtractionInstaller.bad_connection=El servidor rechazï¿½ la conexiï¿½n
+ZipExtractionInstaller.malformed_url=Direcciï¿½n web incorrecta.
+ZipExtractionInstaller.could_not_connect=No se puede conectar a la direcciï¿½n
+InstallSourceProperty.DescriptorImpl.displayName=Instalar automï¿½ticamente
+JDKInstaller.DescriptorImpl.displayName=Instalar desde Oracle
 JDKInstaller.DescriptorImpl.doCheckId=Definir un identificador para el JDK
 JDKInstaller.DescriptorImpl.doCheckAcceptLicense=Debes aceptar la licencia si quieres descargar el JDK.

--- a/hudson-core/src/main/resources/hudson/tools/Messages_ja.properties
+++ b/hudson-core/src/main/resources/hudson/tools/Messages_ja.properties
@@ -31,6 +31,6 @@ ZipExtractionInstaller.bad_connection=\u30b5\u30fc\u30d0\u304c\u63a5\u7d9a\u3092
 ZipExtractionInstaller.malformed_url=URL\u306e\u5f62\u5f0f\u304c\u8aa4\u3063\u3066\u3044\u307e\u3059\u3002
 ZipExtractionInstaller.could_not_connect=URL\u306b\u63a5\u7d9a\u3067\u304d\u307e\u305b\u3093\u3002
 InstallSourceProperty.DescriptorImpl.displayName=\u81ea\u52d5\u30a4\u30f3\u30b9\u30c8\u30fc\u30eb
-JDKInstaller.DescriptorImpl.displayName=java.sun.com\u304b\u3089\u30a4\u30f3\u30b9\u30c8\u30fc\u30eb
+JDKInstaller.DescriptorImpl.displayName=Oracle\u304b\u3089\u30a4\u30f3\u30b9\u30c8\u30fc\u30eb
 JDKInstaller.DescriptorImpl.doCheckId=JDK\u306eID\u3092\u5b9a\u7fa9\u3057\u3066\u304f\u3060\u3055\u3044\u3002
 JDKInstaller.DescriptorImpl.doCheckAcceptLicense=JDK\u3092\u30c0\u30a6\u30f3\u30ed\u30fc\u30c9\u3059\u308b\u306b\u306f\u4f7f\u7528\u8a31\u8afe\u306b\u540c\u610f\u3059\u308b\u5fc5\u8981\u304c\u3042\u308a\u307e\u3059\u3002

--- a/hudson-core/src/main/resources/hudson/tools/Messages_pt_BR.properties
+++ b/hudson-core/src/main/resources/hudson/tools/Messages_pt_BR.properties
@@ -29,7 +29,7 @@ ToolLocationNodeProperty.displayName=Ferramentas Locais
 # Must provide a command to run.
 CommandInstaller.no_command=Deve fornecer um comando a ser executado
 # Install from java.sun.com
-JDKInstaller.DescriptorImpl.displayName=Instalar de java.sun.com
+JDKInstaller.DescriptorImpl.displayName=Instalar de Oracle
 # Failed to install JDK
 JDKInstaller.FailedToInstallJDK=Falha ao instalar JDK
 # Define JDK ID

--- a/hudson-core/src/main/resources/hudson/tools/Messages_zh_CN.properties
+++ b/hudson-core/src/main/resources/hudson/tools/Messages_zh_CN.properties
@@ -31,6 +31,6 @@ ZipExtractionInstaller.bad_connection=\u670d\u52a1\u5668\u62d2\u7edd\u94fe\u63a5
 ZipExtractionInstaller.malformed_url=\u9519\u8bef\u7684URL.
 ZipExtractionInstaller.could_not_connect=\u4e0d\u80fd\u94fe\u63a5URL.
 InstallSourceProperty.DescriptorImpl.displayName=\u81ea\u52a8\u5b89\u88c5
-JDKInstaller.DescriptorImpl.displayName=\u4ece java.sun.com\u5b89\u88c5
+JDKInstaller.DescriptorImpl.displayName=\u4ece Oracle\u5b89\u88c5
 JDKInstaller.DescriptorImpl.doCheckId=\u5b9a\u4e49JDK ID
 JDKInstaller.DescriptorImpl.doCheckAcceptLicense=\u4f60\u5fc5\u987b\u63a5\u53d7\u8bb8\u53ef\u624d\u80fd\u4e0b\u8f7dJDK.


### PR DESCRIPTION
I changed the label from saying download from java.sun.com to just download from Oracle ... the url itself does not really matter anyway and java.sun.com is also wrong now.. 
