### PR TITLE
Bug Fix: HUDSON-7535 - Rebuilding dependency graph slow on large installations

### DIFF
--- a/hudson-core/pom.xml
+++ b/hudson-core/pom.xml
@@ -665,9 +665,9 @@ THE SOFTWARE.
       <version>3.2.7</version>
     </dependency>
     <dependency>
-      <groupId>org.jvnet.hudson</groupId>
+      <groupId>javax.jmdns</groupId>
       <artifactId>jmdns</artifactId>
-      <version>3.2.1-hudson-1</version>
+      <version>3.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.sun.winsw</groupId>

--- a/hudson-core/src/main/java/hudson/DNSMultiCast.java
+++ b/hudson-core/src/main/java/hudson/DNSMultiCast.java
@@ -48,7 +48,11 @@ public class DNSMultiCast implements Closeable {
 
     public void close() {
         if (jmdns!=null) {
-            jmdns.close();
+            try {
+                jmdns.close();
+            } catch (IOException ex) {
+                LOGGER.log(Level.SEVERE, null, ex);
+            }
             jmdns = null;
         }
     }

--- a/hudson-core/src/main/java/hudson/model/DependencyGraph.java
+++ b/hudson-core/src/main/java/hudson/model/DependencyGraph.java
@@ -90,6 +90,11 @@ public final class DependencyGraph implements Comparator<AbstractProject> {
     private boolean built;
 
     /**
+     * A unique set that holds the list of projects that have already computed its dependency graph
+     */
+    private Set<AbstractProject> alreadyComputedProjects = new HashSet<AbstractProject>();
+
+    /**
      * Builds the dependency graph.
      */
     public DependencyGraph() {
@@ -107,6 +112,7 @@ public final class DependencyGraph implements Comparator<AbstractProject> {
             backward = finalize(backward);
 
             built = true;
+            alreadyComputedProjects.clear();
         } finally {
             SecurityContextHolder.setContext(saveCtx);
         }
@@ -119,6 +125,23 @@ public final class DependencyGraph implements Comparator<AbstractProject> {
         forward = backward = Collections.emptyMap();
         built = true;
     }
+
+    /**
+     * Add this project to the set of projects that have already computed its dependency graph
+     * @param project
+     */
+    public void addToAlreadyComputedProjects(AbstractProject project) {
+        alreadyComputedProjects.add(project);
+    }
+
+    /**
+     * Check if the project has already computed its dependency graph
+     * @param project
+     */
+    public boolean isAlreadyComputedProject(AbstractProject project) {
+        return alreadyComputedProjects.contains(this);
+    }
+
 
     /**
      * Gets all the immediate downstream projects (IOW forward edges) of the given project.

--- a/hudson-maven/maven-plugin/src/main/java/hudson/maven/MavenModuleSet.java
+++ b/hudson-maven/maven-plugin/src/main/java/hudson/maven/MavenModuleSet.java
@@ -578,12 +578,19 @@ public final class MavenModuleSet extends AbstractMavenProject<MavenModuleSet,Ma
     }
 
     protected void buildDependencyGraph(DependencyGraph graph) {
+        // This project has already computed its dependency graph
+        if (graph.isAlreadyComputedProject(this)){
+            return;
+        }
     	Collection<MavenModule> modules = getModules();
     	for (MavenModule m : modules) {
     		m.buildDependencyGraph(graph);
     	}
         publishers.buildDependencyGraph(this,graph);
         buildWrappers.buildDependencyGraph(this,graph);
+        
+        // Tell DependencyGraph that this project has computed its dependency graph
+        graph.addToAlreadyComputedProjects(this);
     }
 
     public MavenModule getRootModule() {

--- a/hudson-maven/maven-plugin/src/main/java/hudson/maven/PomInfo.java
+++ b/hudson-maven/maven-plugin/src/main/java/hudson/maven/PomInfo.java
@@ -213,8 +213,7 @@ final class PomInfo implements Serializable {
     }
 
     @Override
-    public boolean equals( Object obj )
-    {
+    public boolean equals( Object obj ){
         if (obj == null) {
             return false;
         }
@@ -225,8 +224,27 @@ final class PomInfo implements Serializable {
             return false;
         }
         PomInfo pomInfo = (PomInfo) obj;
-        return StringUtils.equals( pomInfo.groupId, this.groupId ) 
-            && StringUtils.equals( pomInfo.artifactId, this.artifactId ); 
+        if (!StringUtils.equals( pomInfo.groupId, this.groupId )){
+            return false;
+        }
+        if (!StringUtils.equals( pomInfo.artifactId, this.artifactId )){
+            return false;
+        }
+        return isDependencisesSimilar(pomInfo);
+    }
+
+    private boolean isDependencisesSimilar(PomInfo pom){
+
+        if (pom.dependencies.size() != dependencies.size()){
+            return false;
+        }
+        for (ModuleDependency dependency : dependencies){
+            // This is feasible because ModuleDependency overrides equal and Hashcode
+            if (!pom.dependencies.contains(dependency)){
+                return false;
+            }
+        }
+        return true;
     }
     
     /**


### PR DESCRIPTION
While rebuilding dependency graph, the old dependency graph is thrown away and new DependencyGraph is created from scratch.  However,  between Maven Project and its modules the projects are rebuilding more than one.  This is a real problem when Hudson installation has 100 of projects. The fix is have a hash set of project that are already computed and skip any duplicate computation.

Also when a maven project starts building, the POM is parsed, there is a possibility that the POM might have modified and Modules may be added or removed. So the DependencyGraph need to recomputed. The optimization is to check if there is any change in modules, only if so recompute the dependency graph. 
