### PR TITLE
HUDSON-8787: enable use of global index when bootstrapping

### DIFF
--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/SmoothieContainerBootstrap.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/SmoothieContainerBootstrap.java
@@ -57,7 +57,7 @@ public class SmoothieContainerBootstrap
         ClassSpace space = new ClassSpaceFactory().create(classLoader, types);
 
         // Start up the container
-        SmoothieContainer container = new SmoothieContainerImpl(new ExtensionModule(space));
+        SmoothieContainer container = new SmoothieContainerImpl(new ExtensionModule(space, true));
         Smoothie.setContainer(container);
 
         return container;

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/SmoothieContainerImpl.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/SmoothieContainerImpl.java
@@ -163,7 +163,7 @@ public class SmoothieContainerImpl
         @Override
         protected void configure() {
             ClassSpace space = createClassSpace();
-            install(new ExtensionModule(space));
+            install(new ExtensionModule(space, false));
             super.configure();
         }
 

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/ExtensionModule.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/ExtensionModule.java
@@ -31,17 +31,20 @@ public final class ExtensionModule
 {
     private final ClassSpace space;
 
-    public ExtensionModule(final ClassSpace space) {
+    private final boolean globalIndex;
+
+    public ExtensionModule(final ClassSpace space, final boolean globalIndex) {
         this.space = checkNotNull(space);
+        this.globalIndex = globalIndex;
     }
 
     public void configure(final Binder binder) {
         assert binder != null;
 
          // Scan for @Named components using the bean index
-        binder.install(new SpaceModule(space, BeanScanning.INDEX));
+        binder.install(new SpaceModule(space, globalIndex ? BeanScanning.GLOBAL_INDEX : BeanScanning.INDEX));
 
         // Scan for @Extension components via SezPoz index
-        binder.install(new SezPozExtensionModule(space));
+        binder.install(new SezPozExtensionModule(space, globalIndex));
     }
 }

--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/SezPozExtensionModule.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/SezPozExtensionModule.java
@@ -52,13 +52,16 @@ public final class SezPozExtensionModule
 
     private final ClassSpace space;
 
+    private final boolean globalIndex;
+
     // ----------------------------------------------------------------------
     // Constructors
     // ----------------------------------------------------------------------
 
-    public SezPozExtensionModule( final ClassSpace space )
+    public SezPozExtensionModule( final ClassSpace space, final boolean globalIndex )
     {
         this.space = checkNotNull(space);
+        this.globalIndex = globalIndex;
     }
 
     // ----------------------------------------------------------------------
@@ -67,7 +70,7 @@ public final class SezPozExtensionModule
 
     public void configure( final Binder binder )
     {
-        for ( final SpaceIndexItem item : SpaceIndex.load( Extension.class, Object.class, space ) )
+        for ( final SpaceIndexItem item : SpaceIndex.load( Extension.class, Object.class, space, globalIndex ) )
         {
             try
             {

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@ THE SOFTWARE.
   <properties>
     <aspectjVersion>1.6.10</aspectjVersion>
     <sisuGuiceVersion>3.0.1</sisuGuiceVersion>
-    <sisuInjectVersion>2.1.1</sisuInjectVersion>
+    <sisuInjectVersion>2.2.1</sisuInjectVersion>
   </properties>
 
   <modules>


### PR DESCRIPTION
This patch updates sisu-inject-bean to 2.2.1 which includes a couple of classpath scanning fixes for JBoss AS:

  https://github.com/sonatype/sisu/commit/256f32e42f7c9c7c37c21e503db2b7cb5ee04c62
  https://github.com/sonatype/sisu/commit/dbe31b8ab459af5b06330fa753ce08b84a4e9b9d

The remaining changes in this patch add support for global vs local component indexes - the core should use global indexes, taking advantage of the classloader friendly "getResources" method, while plugins continue to use local indexes (because you don't want to duplicate components already picked up by the core).
