### PR TITLE
HUDSON-8812

### DIFF
--- a/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/SezPozExtensionModule.java
+++ b/hudson-inject/src/main/java/org/hudsonci/inject/internal/extension/SezPozExtensionModule.java
@@ -70,7 +70,7 @@ public final class SezPozExtensionModule
 
     public void configure( final Binder binder )
     {
-        for ( final SpaceIndexItem item : SpaceIndex.load( Extension.class, Object.class, space, globalIndex ) )
+        for ( final SpaceIndexItem<Extension, Object> item : SpaceIndex.load( Extension.class, Object.class, space, globalIndex ) )
         {
             try
             {
@@ -108,7 +108,11 @@ public final class SezPozExtensionModule
             }
             catch ( final Throwable e )
             {
-                log.error("Failed to bind item: {}", item, e);
+                if (item.annotation().optional()) {
+                    log.debug("Failed to bind optional extension: {}", item, e);
+                } else {
+                    log.warn("Failed to bind extension: {}", item, e);
+                }
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@ THE SOFTWARE.
 
   <properties>
     <aspectjVersion>1.6.10</aspectjVersion>
-    <sisuGuiceVersion>3.0.1</sisuGuiceVersion>
-    <sisuInjectVersion>2.2.1</sisuInjectVersion>
+    <sisuGuiceVersion>3.0.2</sisuGuiceVersion>
+    <sisuInjectVersion>2.2.2</sisuInjectVersion>
   </properties>
 
   <modules>


### PR DESCRIPTION
Update to latest sisu-guice and sisu-inject-bean releases, which fixes an issue in the dependency analyzer used to repair broken bindings which was disrupting indirect bindings. Also make sure broken extensions don't affect the rest of the extension list (report as debug/warning depending on whether the extension is optional or not, just like the classic strategy does).

Note: sisu-guice 3.0.2 and sisu-inject-bean 2.2.2 have only just been released, so it may be a couple of hours until they show up on Maven Central and its mirrors at http://repo1.maven.org/maven2/org/sonatype/sisu/sisu-guice/3.0.2/ and http://repo1.maven.org/maven2/org/sonatype/sisu/sisu-inject-bean/2.2.2/ respectively.
