### PR TITLE
Added configuration to disable CAPTCHA on user sign up.

### DIFF
--- a/hudson-core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/hudson-core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -1,8 +1,8 @@
 /*
  * The MIT License
- * 
- * Copyright (c) 2004-2010, Sun Microsystems, Inc., Kohsuke Kawaguchi, David Calavera, Seiji Sogabe
- * 
+ *
+ * Copyright (c) 2004-2011, Oracle Corporation, Kohsuke Kawaguchi, David Calavera, Seiji Sogabe, Anton Kozak
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -27,13 +27,7 @@ import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import hudson.Extension;
 import hudson.Util;
 import hudson.diagnosis.OldDataMonitor;
-import hudson.model.Descriptor;
-import hudson.model.Hudson;
-import hudson.model.ManagementLink;
-import hudson.model.ModelObject;
-import hudson.model.User;
-import hudson.model.UserProperty;
-import hudson.model.UserPropertyDescriptor;
+import hudson.model.*;
 import hudson.security.FederatedLoginService.FederatedIdentity;
 import hudson.tasks.Mailer;
 import hudson.util.PluginServletFilter;
@@ -51,29 +45,19 @@ import org.acegisecurity.providers.encoding.PasswordEncoder;
 import org.acegisecurity.providers.encoding.ShaPasswordEncoder;
 import org.acegisecurity.userdetails.UserDetails;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.ForwardToView;
-import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.HttpResponses;
-import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.*;
 import org.springframework.dao.DataAccessException;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 /**
  * {@link SecurityRealm} that performs authentication by looking up {@link User}.
@@ -92,9 +76,34 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
      */
     private final boolean disableSignup;
 
-    @DataBoundConstructor
+    /**
+     * If true, captcha will be enabled.
+     */
+    private final boolean enableCaptcha;
+
+    /**
+     * @deprecated as of 2.0.1
+     */
+    @Deprecated
     public HudsonPrivateSecurityRealm(boolean allowsSignup) {
         this.disableSignup = !allowsSignup;
+        this.enableCaptcha = true;
+        if(!allowsSignup && !hasSomeUser()) {
+            // if Hudson is newly set up with the security realm and there's no user account created yet,
+            // insert a filter that asks the user to create one
+            try {
+                PluginServletFilter.addFilter(CREATE_FIRST_USER_FILTER);
+            } catch (ServletException e) {
+                throw new AssertionError(e); // never happen because our Filter.init is no-op
+            }
+        }
+    }
+
+    @DataBoundConstructor
+    public HudsonPrivateSecurityRealm(boolean allowsSignup, boolean enableCaptcha) {
+        this.disableSignup = !allowsSignup;
+        this.enableCaptcha = enableCaptcha;
+
         if(!allowsSignup && !hasSomeUser()) {
             // if Hudson is newly set up with the security realm and there's no user account created yet,
             // insert a filter that asks the user to create one
@@ -109,6 +118,15 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
     @Override
     public boolean allowsSignup() {
         return !disableSignup;
+    }
+
+    /**
+     * Checks if captcha is disabled on signup.
+     *
+     * @return true if captcha is disabled on signup.
+     */
+    public boolean isEnableCaptcha() {
+        return enableCaptcha;
     }
 
     /**
@@ -194,7 +212,7 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
             throw HttpResponses.error(SC_UNAUTHORIZED,new Exception("User sign up is prohibited"));
 
         boolean firstUser = !hasSomeUser();
-        User u = createAccount(req, rsp, true, formView);
+        User u = createAccount(req, rsp, enableCaptcha, formView);
         if(u!=null) {
             if(firstUser)
                 tryToMakeAdmin(u);  // the first user should be admin, or else there's a risk of lock out

--- a/hudson-core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
+++ b/hudson-core/src/main/java/hudson/security/HudsonPrivateSecurityRealm.java
@@ -121,9 +121,9 @@ public class HudsonPrivateSecurityRealm extends AbstractPasswordBasedSecurityRea
     }
 
     /**
-     * Checks if captcha is disabled on signup.
+     * Checks if captcha is enabled on signup.
      *
-     * @return true if captcha is disabled on signup.
+     * @return true if captcha is enabled on signup.
      */
     public boolean isEnableCaptcha() {
         return enableCaptcha;

--- a/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/config.jelly
+++ b/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/config.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+Copyright (c) 2004-2011, Oracle Corporation, Kohsuke Kawaguchi, Anton Kozak
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,9 @@ THE SOFTWARE.
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<f:entry title="" help="/help/security/private-realm/allow-signup.html">
-	  <f:checkbox name="privateRealm.allowsSignup" checked="${h.defaultToTrue(instance.allowsSignup())}"
-            title="${%Allow users to sign up}"/>
-  </f:entry>
+        <f:checkbox name="privateRealm.allowsSignup" checked="${h.defaultToTrue(instance.allowsSignup())}"
+                    title="${%Allow users to sign up}"/>
+        <f:checkbox name="privateRealm.enableCaptcha" checked="${h.defaultToTrue(instance.isEnableCaptcha())}"
+                    title="${%Enable captcha on sing up}"/>
+    </f:entry>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
+++ b/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
@@ -1,7 +1,7 @@
 <!--
 The MIT License
 
-Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+Copyright (c) 2004-2011, Oracle Corporation, Kohsuke Kawaguchi, Anton Kozak
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -26,5 +26,5 @@ THE SOFTWARE.
   User self sign up page.
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <local:_entryForm host="${app}" title="${%Sign up}" action="createAccount" captcha="${true}" xmlns:local="/hudson/security/HudsonPrivateSecurityRealm" />
+  <local:_entryForm host="${app}" title="${%Sign up}" action="createAccount" captcha="${it.isEnableCaptcha()}" xmlns:local="/hudson/security/HudsonPrivateSecurityRealm" />
 </j:jelly>

--- a/hudson-war/src/main/webapp/help/security/private-realm/allow-signup.html
+++ b/hudson-war/src/main/webapp/help/security/private-realm/allow-signup.html
@@ -5,4 +5,6 @@
 
   <p>
   When this checkbox is unchecked, someone with the administrator role would have to create accounts. 
+  <p>
+  By default, Hudson uses captcha if user creates account by themselves. If you'd like to disable CAPTCHA verification, uncheck appropriate checkbox.
 </div>


### PR DESCRIPTION
I propose to add this option in core instead of "strange" plugin http://wiki.hudson-ci.org//display/HUDSON/Security+No+CAPTCHA. This option is required for UI automated testing. I think that we should cover Hudson Access Control functionality with tests.
