### PR TITLE
Resolve issue HUDSON-5336. Improve logic

### DIFF
--- a/hudson-core/src/main/java/hudson/model/User.java
+++ b/hudson-core/src/main/java/hudson/model/User.java
@@ -274,10 +274,10 @@ public class User extends AbstractModelObject implements AccessControlled, Savea
 
         synchronized(byName) {
             User u = byName.get(id);
-            if(u==null) {
-                User tmp = new User(id, idOrFullName);
-                if (create || tmp.getConfigFile().exists()) {
-                    byName.put(id,u=tmp);
+            if(u==null && create) {
+                u = new User(id, idOrFullName);
+                if (u.getConfigFile().exists()) {
+                    byName.put(id,u);
                 }
             }
             return u;


### PR DESCRIPTION
Auto-creation is still supported, but newly created users wouldn't appear on people page.
User.get(String idOrFullName, boolean create) was re-implemented according to javadoc description

http://issues.hudson-ci.org/browse/HUDSON-5336
