### PR TITLE
Fix for HUDSON-3824 Per-project matrix authorization strategy isn't accurate for newly created projects

### DIFF
--- a/hudson-core/src/main/java/hudson/Functions.java
+++ b/hudson-core/src/main/java/hudson/Functions.java
@@ -45,6 +45,7 @@ import hudson.model.ParameterDefinition.ParameterDescriptor;
 import hudson.model.Project;
 import hudson.model.Run;
 import hudson.model.TopLevelItem;
+import hudson.model.User;
 import hudson.model.View;
 import hudson.model.JDK;
 import hudson.search.SearchableModelObject;
@@ -1312,4 +1313,13 @@ public class Functions {
         return Boolean.getBoolean("hudson.security.ArtifactsPermission");
     }
 
+    /**
+     * Returns true if current user is the author of the job.
+     * @param job job.
+     * @return returns true if current user is the author of the job.
+     */
+    public static boolean isAuthor(Job job) {
+        User user = User.current();
+        return !(user == null || job == null || job.getCreatedBy() == null) && job.getCreatedBy().equals(user.getId());
+    }
 }

--- a/hudson-core/src/main/java/hudson/model/Job.java
+++ b/hudson-core/src/main/java/hudson/model/Job.java
@@ -24,61 +24,58 @@
  */
 package hudson.model;
 
-import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
-
+import com.google.common.collect.Sets;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
+import hudson.Extension;
 import hudson.ExtensionPoint;
 import hudson.PermalinkList;
-import hudson.Extension;
 import hudson.cli.declarative.CLIResolver;
 import hudson.model.Descriptor.FormException;
-import hudson.model.PermalinkProjectAction.Permalink;
-import hudson.model.Fingerprint.RangeSet;
 import hudson.model.Fingerprint.Range;
+import hudson.model.Fingerprint.RangeSet;
+import hudson.model.PermalinkProjectAction.Permalink;
 import hudson.search.QuickSilver;
 import hudson.search.SearchIndex;
 import hudson.search.SearchIndexBuilder;
 import hudson.search.SearchItem;
 import hudson.search.SearchItems;
 import hudson.security.ACL;
+import hudson.security.AuthorizationMatrixProperty;
+import hudson.security.Permission;
+import hudson.security.ProjectMatrixAuthorizationStrategy;
 import hudson.tasks.LogRotator;
 import hudson.util.ChartUtil;
 import hudson.util.ColorPalette;
 import hudson.util.CopyOnWriteList;
 import hudson.util.DataSetBuilder;
+import hudson.util.Graph;
 import hudson.util.IOException2;
 import hudson.util.RunList;
 import hudson.util.ShiftedCategoryAxis;
 import hudson.util.StackedAreaRenderer2;
 import hudson.util.TextFile;
-import hudson.util.Graph;
 import hudson.widgets.HistoryWidget;
-import hudson.widgets.Widget;
 import hudson.widgets.HistoryWidget.Adapter;
-
-import java.awt.Color;
-import java.awt.Paint;
+import hudson.widgets.Widget;
+import java.awt.*;
 import java.io.File;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.URLEncoder;
-import java.util.AbstractList;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
-import java.util.LinkedList;
-
 import javax.servlet.ServletException;
-
-import net.sf.json.JSONObject;
 import net.sf.json.JSONException;
-
+import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.JFreeChart;
@@ -91,16 +88,19 @@ import org.jfree.chart.renderer.category.StackedAreaRenderer;
 import org.jfree.data.category.CategoryDataset;
 import org.jfree.ui.RectangleInsets;
 import org.jvnet.localizer.Localizable;
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.stapler.StaplerOverridable;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.args4j.Argument;
-import org.kohsuke.args4j.CmdLineException;
+
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
 
 /**
  * A job is an runnable entity under the monitoring of Hudson.
- * 
+ *
  * <p>
  * Every time it "runs", it will be recorded as a {@link Run} object.
  *
@@ -140,6 +140,16 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     private transient List<HealthReport> cachedBuildHealthReports = null;
 
     private boolean keepDependencies;
+
+    /**
+     * The author of the job;
+     */
+    protected volatile String createdBy;
+
+    /**
+     * The time when the job was created;
+     */
+    private volatile long creationTime;
 
     /**
      * List of {@link UserProperty}s configured for this project.
@@ -192,6 +202,34 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
         synchronized (this) {
             this.nextBuildNumber = 1; // reset the next build number
             this.holdOffBuildUntilSave = true;
+            this.creationTime = new GregorianCalendar().getTimeInMillis();
+            User user = User.current();
+            if (user != null){
+                this.createdBy = user.getId();
+                grantProjectMatrixPermissions(user);
+            }
+        }
+    }
+
+    /**
+     * Grants project permissions to the user.
+     *
+     * @param user user
+     */
+    protected void grantProjectMatrixPermissions(User user) {
+        if (Hudson.getInstance().getAuthorizationStrategy() instanceof ProjectMatrixAuthorizationStrategy) {
+            Map<Permission, Set<String>> grantedPermissions = new HashMap<Permission, Set<String>>();
+            Set<String> users = Sets.newHashSet(user.getId());
+            grantedPermissions.put(Item.BUILD, users);
+            grantedPermissions.put(Item.CONFIGURE, users);
+            grantedPermissions.put(Item.DELETE, users);
+            grantedPermissions.put(Item.READ, users);
+            grantedPermissions.put(Item.WORKSPACE, users);
+            grantedPermissions.put(Run.DELETE, users);
+            grantedPermissions.put(Run.UPDATE, users);
+            AuthorizationMatrixProperty amp = new AuthorizationMatrixProperty(grantedPermissions);
+            amp.setOwner(this);
+            properties.add(amp);
         }
     }
 
@@ -284,12 +322,12 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
     /**
      * Programatically updates the next build number.
-     * 
+     *
      * <p>
      * Much of Hudson assumes that the build number is unique and monotonic, so
      * this method can only accept a new value that's bigger than
      * {@link #getLastBuild()} returns. Otherwise it'll be no-op.
-     * 
+     *
      * @since 1.199 (before that, this method was package private.)
      */
     public synchronized void updateNextBuildNumber(int next) throws IOException {
@@ -356,7 +394,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
     /**
      * Adds {@link JobProperty}.
-     * 
+     *
      * @since 1.188
      */
     public void addProperty(JobProperty<? super JobT> jobProp) throws IOException {
@@ -485,7 +523,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
     /**
      * Gets the read-only view of all the builds.
-     * 
+     *
      * @return never null. The first entry is the latest build.
      */
     @Exported
@@ -566,7 +604,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
     /**
      * Gets the youngest build #m that satisfies <tt>n&lt;=m</tt>.
-     * 
+     *
      * This is useful when you'd like to fetch a build but the exact build might
      * be already gone (deleted, rotated, etc.)
      */
@@ -580,7 +618,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
     /**
      * Gets the latest build #m that satisfies <tt>m&lt;=n</tt>.
-     * 
+     *
      * This is useful when you'd like to fetch a build but the exact build might
      * be already gone (deleted, rotated, etc.)
      */
@@ -636,7 +674,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
     /**
      * Gets all the runs.
-     * 
+     *
      * The resulting map must be immutable (by employing copy-on-write
      * semantics.) The map is descending order, with newest builds at the top.
      */
@@ -644,7 +682,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
     /**
      * Called from {@link Run} to remove it from this job.
-     * 
+     *
      * The files are deleted already. So all the callee needs to do is to remove
      * a reference from this {@link Job}.
      */
@@ -679,7 +717,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     /**
      * Returns the last successful build, if any. Otherwise null. A successful build
      * would include either {@link Result#SUCCESS} or {@link Result#UNSTABLE}.
-     * 
+     *
      * @see #getLastStableBuild()
      */
     @Exported
@@ -759,32 +797,32 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
             r = r.getPreviousBuild();
         return r;
     }
-    
+
     /**
      * Returns the last 'numberOfBuilds' builds with a build result >= 'threshold'
-     * 
+     *
      * @return a list with the builds. May be smaller than 'numberOfBuilds' or even empty
      *   if not enough builds satisfying the threshold have been found. Never null.
      */
     public List<RunT> getLastBuildsOverThreshold(int numberOfBuilds, Result threshold) {
-        
+
         List<RunT> result = new ArrayList<RunT>(numberOfBuilds);
-        
+
         RunT r = getLastBuild();
         while (r != null && result.size() < numberOfBuilds) {
-            if (!r.isBuilding() && 
+            if (!r.isBuilding() &&
                  (r.getResult() != null && r.getResult().isBetterOrEqualTo(threshold))) {
                 result.add(r);
             }
             r = r.getPreviousBuild();
         }
-        
+
         return result;
     }
-    
+
     public final long getEstimatedDuration() {
         List<RunT> builds = getLastBuildsOverThreshold(3, Result.UNSTABLE);
-        
+
         if(builds.isEmpty())     return -1;
 
         long totalDuration = 0;
@@ -830,7 +868,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
 
     /**
      * Get the current health report for a job.
-     * 
+     *
      * @return the health report. Never returns null
      */
     public HealthReport getBuildHealth() {
@@ -955,7 +993,7 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
                 logRotator = LogRotator.DESCRIPTOR.newInstance(req,json.getJSONObject("logrotate"));
             else
                 logRotator = null;
-            
+
             int i = 0;
             for (JobPropertyDescriptor d : JobPropertyDescriptor
                     .getPropertyDescriptors(Job.this.getClass())) {
@@ -1231,4 +1269,44 @@ public abstract class Job<JobT extends Job<JobT, RunT>, RunT extends Run<JobT, R
     public BuildTimelineWidget getTimeline() {
         return new BuildTimelineWidget(getBuilds());
     }
+
+    /**
+     * Returns the author of the job.
+     *
+     * @return the author of the job.
+     * @since 2.0.1
+     */
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    /**
+     * Sets the author of the job.
+     *
+     * @param createdBy the author of the job.
+     */
+    protected void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    /**
+     * Returns time when the project was created.
+     *
+     * @return time when the project was created.
+     * @since 2.0.1
+     */
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    /**
+     * Sets time when the job was created.
+     *
+     * @param creationTime time when the job was created.
+     */
+    protected void setCreationTime(long creationTime) {
+        this.creationTime = creationTime;
+    }
+
+
 }

--- a/hudson-core/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
+++ b/hudson-core/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
@@ -99,7 +99,7 @@ THE SOFTWARE.
         <local:row sid="${null}" />
       </tr>
     </table>
-    <table style="margin-top:0.5em; margin-left: 2em; width: 100%" id="add-user-tbl">
+    <table style="margin-top:0.5em; margin-left: 2em; width: 100%">
      <tr><td colspan="3">
       ${%User/group to add}:
       <input type="text" id="${id}text" />

--- a/hudson-core/src/test/java/hudson/FunctionsTest.java
+++ b/hudson-core/src/test/java/hudson/FunctionsTest.java
@@ -1,0 +1,120 @@
+package hudson;
+
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011, Oracle Corporation, Anton Kozak
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Job;
+import hudson.model.User;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.easymock.EasyMock.expect;
+import static org.powermock.api.easymock.PowerMock.createMock;
+import static org.powermock.api.easymock.PowerMock.mockStatic;
+import static org.powermock.api.easymock.PowerMock.replay;
+import static org.powermock.api.easymock.PowerMock.verify;
+
+/**
+ * Test for {@link Functions}
+ * <p/>
+ * Date: 5/19/11
+ *
+ * @author Anton Kozak
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(User.class)
+public class FunctionsTest {
+    private static final String USER = "admin";
+
+    @Test
+    public void testIsAuthorTrue() throws Exception {
+        mockStatic(User.class);
+        User user = createMock(User.class);
+        expect(user.getId()).andReturn(USER);
+        expect(User.current()).andReturn(user);
+        Job job = createMock(FreeStyleProject.class);
+        expect(job.getCreatedBy()).andReturn(USER).times(2);
+        replay(User.class, user, job);
+        boolean result = Functions.isAuthor(job);
+        verify(User.class, user, job);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsAuthorFalse() throws Exception {
+        mockStatic(User.class);
+        User user = createMock(User.class);
+        expect(user.getId()).andReturn(USER);
+        expect(User.current()).andReturn(user);
+        Job job = createMock(FreeStyleProject.class);
+        expect(job.getCreatedBy()).andReturn("user").times(2);
+        replay(User.class, user, job);
+        boolean result = Functions.isAuthor(job);
+        verify(User.class, user, job);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIsAuthorJobCreatedByNull() throws Exception {
+        mockStatic(User.class);
+        User user = createMock(User.class);
+        expect(User.current()).andReturn(user);
+        Job job = createMock(FreeStyleProject.class);
+        expect(job.getCreatedBy()).andReturn(null);
+        replay(User.class, user, job);
+        boolean result = Functions.isAuthor(job);
+        verify(User.class, user, job);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIsAuthorUserIdNull() throws Exception {
+        mockStatic(User.class);
+        User user = createMock(User.class);
+        expect(user.getId()).andReturn(null);
+        expect(User.current()).andReturn(user);
+        Job job = createMock(FreeStyleProject.class);
+        expect(job.getCreatedBy()).andReturn(USER).times(2);
+        replay(User.class, user, job);
+        boolean result = Functions.isAuthor(job);
+        verify(User.class, user, job);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIsAuthorUserNull() throws Exception {
+        mockStatic(User.class);
+        expect(User.current()).andReturn(null);
+        Job job = createMock(FreeStyleProject.class);
+        replay(User.class, job);
+        boolean result = Functions.isAuthor(job);
+        verify(User.class, job);
+        assertFalse(result);
+    }
+}

--- a/hudson-core/src/test/java/hudson/model/FreeStyleProjectTest.java
+++ b/hudson-core/src/test/java/hudson/model/FreeStyleProjectTest.java
@@ -1,0 +1,227 @@
+package hudson.model;
+
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2011, Oracle Corporation, Anton Kozak
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import com.google.common.collect.Lists;
+import hudson.matrix.MatrixProject;
+import hudson.security.AuthorizationMatrixProperty;
+import hudson.security.AuthorizationStrategy;
+import hudson.security.GlobalMatrixAuthorizationStrategy;
+import hudson.security.ProjectMatrixAuthorizationStrategy;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
+import static org.easymock.EasyMock.expect;
+import static org.powermock.api.easymock.PowerMock.createMock;
+import static org.powermock.api.easymock.PowerMock.mockStatic;
+import static org.powermock.api.easymock.PowerMock.replayAll;
+import static org.powermock.api.easymock.PowerMock.verifyAll;
+
+/**
+ * Test for {@link FreeStyleProject}
+ * <p/>
+ * Date: 5/20/11
+ *
+ * @author Anton Kozak
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Hudson.class, User.class})
+public class FreeStyleProjectTest {
+    private static final String USER = "admin";
+
+    @Test
+    public void testOnCreatedFromScratch(){
+        Hudson hudson = createMock(Hudson.class);
+        expect(hudson.getNodes()).andReturn(Lists.<Node>newArrayList()).times(2);
+        AuthorizationStrategy authorizationStrategy = createMock(ProjectMatrixAuthorizationStrategy.class);
+        expect(hudson.getAuthorizationStrategy()).andReturn(authorizationStrategy);
+        mockStatic(Hudson.class);
+        expect(Hudson.getInstance()).andReturn(hudson).anyTimes();
+        User user = createMock(User.class);
+        expect(user.getId()).andReturn(USER).times(2);
+        mockStatic(User.class);
+        expect(User.current()).andReturn(user);
+        replayAll();
+        MatrixProject matrixProjectProject = new MatrixProject("matrixProject");
+        FreeStyleProject freeStyleProject = new FreeStyleProject(matrixProjectProject, "testJob"){
+            @Override
+            protected void updateTransientActions() {
+            }
+        };
+        freeStyleProject.onCreatedFromScratch();
+        verifyAll();
+        assertNotNull(freeStyleProject.getCreationTime());
+        assertEquals(freeStyleProject.getCreatedBy(), USER);
+        List properties = freeStyleProject.getAllProperties();
+        assertEquals(properties.size(), 1);
+        AuthorizationMatrixProperty property = (AuthorizationMatrixProperty)properties.get(0);
+        assertEquals(property.getGrantedPermissions().keySet().size(), 7);
+        assertNotNull(property.getGrantedPermissions().get(Item.CONFIGURE));
+        assertTrue(property.getGrantedPermissions().get(Item.CONFIGURE).contains(USER));
+    }
+
+    @Test
+    public void testOnCreatedFromScratchGlobalMatrixAuthorizationStrategy(){
+        Hudson hudson = createMock(Hudson.class);
+        expect(hudson.getNodes()).andReturn(Lists.<Node>newArrayList()).times(2);
+        AuthorizationStrategy authorizationStrategy = createMock(GlobalMatrixAuthorizationStrategy.class);
+        expect(hudson.getAuthorizationStrategy()).andReturn(authorizationStrategy);
+        mockStatic(Hudson.class);
+        expect(Hudson.getInstance()).andReturn(hudson).anyTimes();
+        User user = createMock(User.class);
+        expect(user.getId()).andReturn(USER).times(1);
+        mockStatic(User.class);
+        expect(User.current()).andReturn(user);
+        replayAll();
+        MatrixProject matrixProjectProject = new MatrixProject("matrixProject");
+        FreeStyleProject freeStyleProject = new FreeStyleProject(matrixProjectProject, "testJob"){
+            @Override
+            protected void updateTransientActions() {
+            }
+        };
+        freeStyleProject.onCreatedFromScratch();
+        verifyAll();
+        assertNotNull(freeStyleProject.getCreationTime());
+        assertEquals(freeStyleProject.getCreatedBy(), USER);
+        List properties = freeStyleProject.getAllProperties();
+        assertEquals(properties.size(), 0);
+    }
+
+    @Test
+    public void testOnCreatedFromScratchAnonymousAuthentication(){
+        Hudson hudson = createMock(Hudson.class);
+        expect(hudson.getNodes()).andReturn(Lists.<Node>newArrayList()).times(2);
+        mockStatic(Hudson.class);
+        expect(Hudson.getInstance()).andReturn(hudson).anyTimes();
+        mockStatic(User.class);
+        expect(User.current()).andReturn(null);
+        replayAll();
+        MatrixProject matrixProjectProject = new MatrixProject("matrixProject");
+        FreeStyleProject freeStyleProject = new FreeStyleProject(matrixProjectProject, "testJob"){
+            @Override
+            protected void updateTransientActions() {
+            }
+        };
+        freeStyleProject.onCreatedFromScratch();
+        verifyAll();
+        assertNotNull(freeStyleProject.getCreationTime());
+        assertNull(freeStyleProject.getCreatedBy());
+        List properties = freeStyleProject.getAllProperties();
+        assertEquals(properties.size(), 0);
+    }
+
+    @Test
+    public void testOnCopiedFrom(){
+        Hudson hudson = createMock(Hudson.class);
+        expect(hudson.getNodes()).andReturn(Lists.<Node>newArrayList()).times(2);
+        AuthorizationStrategy authorizationStrategy = createMock(ProjectMatrixAuthorizationStrategy.class);
+        expect(hudson.getAuthorizationStrategy()).andReturn(authorizationStrategy);
+        mockStatic(Hudson.class);
+        expect(Hudson.getInstance()).andReturn(hudson).anyTimes();
+        User user = createMock(User.class);
+        expect(user.getId()).andReturn(USER).times(2);
+        mockStatic(User.class);
+        expect(User.current()).andReturn(user);
+        replayAll();
+        MatrixProject matrixProjectProject = new MatrixProject("matrixProject");
+        FreeStyleProject freeStyleProject = new FreeStyleProject(matrixProjectProject, "testJob"){
+            @Override
+            protected void updateTransientActions() {
+            }
+        };
+        freeStyleProject.onCopiedFrom(matrixProjectProject);
+        verifyAll();
+        assertEquals(freeStyleProject.getNextBuildNumber(), 1);
+        assertTrue(freeStyleProject.isHoldOffBuildUntilSave());
+        assertNotNull(freeStyleProject.getCreationTime());
+        assertEquals(freeStyleProject.getCreatedBy(), USER);
+        List properties = freeStyleProject.getAllProperties();
+        assertEquals(properties.size(), 1);
+        AuthorizationMatrixProperty property = (AuthorizationMatrixProperty)properties.get(0);
+        assertEquals(property.getGrantedPermissions().keySet().size(), 7);
+        assertNotNull(property.getGrantedPermissions().get(Item.CONFIGURE));
+        assertTrue(property.getGrantedPermissions().get(Item.CONFIGURE).contains(USER));
+    }
+
+    @Test
+    public void testOnCopiedFromGlobalMatrixAuthorizationStrategy(){
+        Hudson hudson = createMock(Hudson.class);
+        expect(hudson.getNodes()).andReturn(Lists.<Node>newArrayList()).times(2);
+        AuthorizationStrategy authorizationStrategy = createMock(GlobalMatrixAuthorizationStrategy.class);
+        expect(hudson.getAuthorizationStrategy()).andReturn(authorizationStrategy);
+        mockStatic(Hudson.class);
+        expect(Hudson.getInstance()).andReturn(hudson).anyTimes();
+        User user = createMock(User.class);
+        expect(user.getId()).andReturn(USER).times(1);
+        mockStatic(User.class);
+        expect(User.current()).andReturn(user);
+        replayAll();
+        MatrixProject matrixProjectProject = new MatrixProject("matrixProject");
+        FreeStyleProject freeStyleProject = new FreeStyleProject(matrixProjectProject, "testJob"){
+            @Override
+            protected void updateTransientActions() {
+            }
+        };
+        freeStyleProject.onCopiedFrom(matrixProjectProject);
+        verifyAll();
+        assertEquals(freeStyleProject.getNextBuildNumber(), 1);
+        assertTrue(freeStyleProject.isHoldOffBuildUntilSave());
+        assertNotNull(freeStyleProject.getCreationTime());
+        assertEquals(freeStyleProject.getCreatedBy(), USER);
+        assertEquals(freeStyleProject.getAllProperties().size(), 0);
+    }
+
+    @Test
+    public void testOnCopiedFromAnonymousAuthentication(){
+        Hudson hudson = createMock(Hudson.class);
+        expect(hudson.getNodes()).andReturn(Lists.<Node>newArrayList()).times(2);
+        mockStatic(Hudson.class);
+        expect(Hudson.getInstance()).andReturn(hudson).anyTimes();
+        mockStatic(User.class);
+        expect(User.current()).andReturn(null);
+        replayAll();
+        MatrixProject matrixProjectProject = new MatrixProject("matrixProject");
+        FreeStyleProject freeStyleProject = new FreeStyleProject(matrixProjectProject, "testJob"){
+            @Override
+            protected void updateTransientActions() {
+            }
+        };
+        freeStyleProject.onCopiedFrom(matrixProjectProject);
+        verifyAll();
+        assertEquals(freeStyleProject.getNextBuildNumber(), 1);
+        assertTrue(freeStyleProject.isHoldOffBuildUntilSave());
+        assertNotNull(freeStyleProject.getCreationTime());
+        assertNull(freeStyleProject.getCreatedBy());
+        List properties = freeStyleProject.getAllProperties();
+        assertEquals(properties.size(), 0);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>r08</version>
+        <version>r09</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Fix for HUDSON-3824 Per-project matrix authorization strategy isn't accurate for newly created projects
