### PR TITLE
Update hudson-plugin-parent.pom

### DIFF
--- a/hudson-plugin-parent/pom.xml
+++ b/hudson-plugin-parent/pom.xml
@@ -128,7 +128,7 @@
           <plugin>
             <groupId>org.jvnet.hudson.tools</groupId>
             <artifactId>maven-hpi-plugin</artifactId>
-            <version>2.0.0</version>
+            <version>${project.version}</version>
             <extensions>true</extensions>
             <configuration>
               <showDeprecation>true</showDeprecation>


### PR DESCRIPTION
Fix hudson-plugin-parent.pom (Invalid dependency version of maven-hpi-plugin)
