### PR TITLE
HUDSON-8900: executors which have died with a cause of death shouldn't be considered as 'idle' since they can never accept any more work

### DIFF
--- a/hudson-core/src/main/java/hudson/model/Executor.java
+++ b/hudson-core/src/main/java/hudson/model/Executor.java
@@ -253,14 +253,14 @@ public class Executor extends Thread implements ModelObject {
      */
     @Exported
     public boolean isIdle() {
-        return executable==null;
+        return executable==null && causeOfDeath==null;
     }
 
     /**
      * The opposite of {@link #isIdle()} &mdash; the executor is doing some work.
      */
     public boolean isBusy() {
-        return executable!=null;
+        return executable!=null || causeOfDeath!=null;
     }
 
     /**
@@ -401,10 +401,11 @@ public class Executor extends Thread implements ModelObject {
      * Returns when this executor started or should start being idle.
      */
     public long getIdleStartMilliseconds() {
-        if (isIdle())
+        Queue.Executable e = executable;
+        if (e == null)
             return Math.max(finishTime, owner.getConnectTime());
         else {
-            return Math.max(startTime + Math.max(0, Executables.getEstimatedDurationFor(executable)),
+            return Math.max(startTime + Math.max(0, Executables.getEstimatedDurationFor(e)),
                     System.currentTimeMillis() + 15000);
         }
     }

--- a/hudson-test-framework/pom.xml
+++ b/hudson-test-framework/pom.xml
@@ -65,6 +65,11 @@
 
     <dependency>
       <groupId>org.jvnet.hudson.main</groupId>
+      <artifactId>rest-plugin</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jvnet.hudson.main</groupId>
       <artifactId>maven-plugin</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -72,18 +77,6 @@
     <dependency>
       <groupId>org.jvnet.hudson.main</groupId>
       <artifactId>hudson-cli</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-server</artifactId>
-      <version>1.5</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.cometd.java</groupId>
-      <artifactId>cometd-java-server</artifactId>
-      <version>1.1.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The improved main page layout avoids showing idle executors, which is useful when you have large build farms with lots of computers and idle executors. However, we also want to show executors that died with an exception cause so the administrator can check them and manually clear them.

This patch treats dead executors with an exception cause as "busy" - this is reasonable since the executor can never again accept work. IMHO it is also the safest change since it maintains the "idle == !busy" assumption; introducing a third state ("dead") could upset various checks and statistics that assume that there are only two executor states.

This patch also fixes a potential race condition in getIdleStartMilliseconds where the volatile executor field was checked and then retrieved in a separate operation - rather than copied to a local variable and then checked.
