### PR TITLE
Resolve HUDSON-3924

### DIFF
--- a/hudson-core/src/main/java/hudson/model/Hudson.java
+++ b/hudson-core/src/main/java/hudson/model/Hudson.java
@@ -1258,6 +1258,18 @@ public final class Hudson extends Node implements ItemGroup<TopLevelItem>, Stapl
         return viewableItems;
     }
 
+    @Exported(name = "securedJobs")
+    public List<TopLevelItem> getSecuredItems() {
+        List<TopLevelItem> viewableItems = new ArrayList<TopLevelItem>();
+        for (TopLevelItem item : items.values()) {
+            if (!item.hasPermission(Item.READ)) {
+                viewableItems.add(item);
+            }
+        }
+
+        return viewableItems;
+    }
+
     /**
      * Returns the read-only view of all the {@link TopLevelItem}s keyed by their names.
      * <p>


### PR DESCRIPTION
Resolve HUDSON-3924. SecuredJob section was added to api/xml. Jobs which require authorization will be displayed in this section

http://issues.hudson-ci.org/browse/HUDSON-3924
