### PR TITLE
Fix globalMessages population and displaying

### DIFF
--- a/hudson-core/src/main/resources/lib/layout/layout.jelly
+++ b/hudson-core/src/main/resources/lib/layout/layout.jelly
@@ -236,10 +236,10 @@ THE SOFTWARE.
           <table width="100%" height="100%" border="0">
             <tr>
               <td id="global-messages" width="100%">
-                <j:forEach var="message" items="${app.globalMessages}">
-                  <j:if test="${message.enabled}">
+                <j:forEach var="globalMessage" items="${app.globalMessages}">
+                  <j:if test="${globalMessage.enabled}">
                     <div class="global-message">
-                      <st:include page="detail.jelly" it="${message}"/>
+                      <st:include page="detail.jelly" it="${globalMessage}"/>
                     </div>
                   </j:if>
                 </j:forEach>


### PR DESCRIPTION
Fix globalMessages population. Foreach param clashes with response error message param.
Response contains "message" param which was overridden by global message section
