### PR TITLE
Resolve HUDSON-8926 (Unix security not working - libpam.so not found)

### DIFF
--- a/hudson-core/pom.xml
+++ b/hudson-core/pom.xml
@@ -685,7 +685,7 @@ THE SOFTWARE.
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>3.2.4</version>
+      <version>3.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.sun.akuma</groupId>


### PR DESCRIPTION
Rev-up JNA version to 3.3.0. Resolve HUDSON-8926 (Unix security not working - libpam.so not found)
JNA-3.3.0 contains fix for http://java.net/jira/browse/JNA-184 which affects http://issues.hudson-ci.org/browse/HUDSON-8926
