### PR TITLE
Resolve HUDSON-6629 (Cannot restart Hudson from the web frontend on OpenSolaris in VirtualBox)

### DIFF
--- a/hudson-core/pom.xml
+++ b/hudson-core/pom.xml
@@ -688,9 +688,9 @@ THE SOFTWARE.
       <version>3.3.0</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.akuma</groupId>
+      <groupId>org.kohsuke</groupId>
       <artifactId>akuma</artifactId>
-      <version>1.4</version>
+      <version>1.6</version>
     </dependency>
     <dependency>
       <groupId>org.jvnet.libpam4j</groupId>


### PR DESCRIPTION
Resolve HUDSON-6629 (Cannot restart Hudson from the web frontend on OpenSolaris in VirtualBox). Use fixed acuma library version
http://issues.hudson-ci.org/browse/HUDSON-6629
