### PR TITLE
JDK automatic installer temporarily disabled because of NPE at hudson.tools.JDKInstaller.locateStage1(JDKInstaller.java:347). The reason is changed oracle JDK download page.

### DIFF
--- a/hudson-core/src/main/resources/hudson/tools/ToolInstallation/global.jelly
+++ b/hudson-core/src/main/resources/hudson/tools/ToolInstallation/global.jelly
@@ -29,8 +29,19 @@ THE SOFTWARE.
         <j:set var="toolDescriptor" value="${descriptor}" /><!-- to make this descriptor accessible from properties -->
         <table width="100%">
           <st:include page="config.jelly" from="${descriptor}" class="${descriptor.clazz}"/>
-          <f:descriptorList descriptors="${descriptor.propertyDescriptors}" field="properties"/>
-          <f:entry title="">
+            <!-- TODO enable JDK installer when it will be ready -->
+            <j:choose>
+                <j:when test="${descriptor.displayName=='JDK'}">
+                    <tr>
+                        <td colspan="2"/>
+                        <td><div style="text-align:left; color:red; font-weight:bold">${%jdk.installed.disabled}</div></td>
+                    </tr>
+                </j:when>
+                <j:otherwise>
+                    <f:descriptorList descriptors="${descriptor.propertyDescriptors}" field="properties"/>
+                </j:otherwise>
+            </j:choose>
+            <f:entry title="">
             <div align="right">
               <f:repeatableDeleteButton value="${%label.delete(descriptor.displayName)}"/>
             </div>

--- a/hudson-core/src/main/resources/hudson/tools/ToolInstallation/global.properties
+++ b/hudson-core/src/main/resources/hudson/tools/ToolInstallation/global.properties
@@ -24,3 +24,4 @@ title={0} installations
 description=List of {0} installations on this system
 label.add=Add {0}
 label.delete=Delete {0}
+jdk.installed.disabled=JDK automatic installer temporarily disabled, please install JDK manually and specify valid JAVA_HOME


### PR DESCRIPTION
JDK automatic installer temporarily disabled because of NPE at hudson.tools.JDKInstaller.locateStage1(JDKInstaller.java:347). The reason is changed oracle JDK download page.
