### PR TITLE
HUDSON-4433: update log4j to 1.2.12 and commons-logging to 1.1.1

### DIFF
--- a/hudson-core/pom.xml
+++ b/hudson-core/pom.xml
@@ -389,7 +389,6 @@ THE SOFTWARE.
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
-      <version>2.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -599,8 +598,30 @@ THE SOFTWARE.
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-      <version>1.1</version>
+      <version>1.1.1</version>
     </dependency>
+    <!--
+     | these are now optional in commons-logging:1.1.1,
+     | keeping them around in case any plugins use them
+     -->
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.12</version>
+    </dependency>
+    <dependency>
+      <groupId>logkit</groupId>
+      <artifactId>logkit</artifactId>
+      <version>1.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>avalon-framework</groupId>
+      <artifactId>avalon-framework</artifactId>
+      <version>4.1.3</version>
+    </dependency>
+    <!--
+     | ^ end of optional commons-logging dependencies
+     -->
     <dependency>
       <groupId>com.sun.xml.txw2</groupId>
       <artifactId>txw2</artifactId>

--- a/hudson-inject/pom.xml
+++ b/hudson-inject/pom.xml
@@ -65,9 +65,13 @@ THE SOFTWARE.
     </dependency>
 
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.jvnet.hudson.main</groupId>
       <artifactId>hudson-core</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/hudson-maven-legacy/maven-plugin/pom.xml
+++ b/hudson-maven-legacy/maven-plugin/pom.xml
@@ -52,7 +52,6 @@ THE SOFTWARE.
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>servlet-api</artifactId>
-      <version>2.4</version>
       <scope>provided</scope>
     </dependency>
     

--- a/hudson-rest/pom.xml
+++ b/hudson-rest/pom.xml
@@ -99,12 +99,6 @@ THE SOFTWARE.
         <version>1.1.2</version>
       </dependency>
 
-      <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>servlet-api</artifactId>
-        <version>2.4</version>
-      </dependency>
-
       <!-- INTERNAL -->
 
       <dependency>

--- a/hudson-war/pom.xml
+++ b/hudson-war/pom.xml
@@ -236,6 +236,12 @@ THE SOFTWARE.
 
   <dependencies>
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.jvnet.hudson.main</groupId>
       <artifactId>hudson-core</artifactId>
       <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,12 @@ THE SOFTWARE.
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>servlet-api</artifactId>
+        <version>2.4</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>1.6.1</version>


### PR DESCRIPTION
This patch also keeps some commons-logging dependencies that are now optional (such as the avalon and logkit loggers) in case plugins depend on them.
