### PR TITLE
Resolve HUDSON-7926 (Add time execution of the build on build detail page)

### DIFF
--- a/hudson-core/src/main/resources/hudson/model/AbstractBuild/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractBuild/index.jelly
@@ -36,7 +36,13 @@ THE SOFTWARE.
         </l:hasPermission>
         <div style="margin-top:1em">
           ${%startedAgo(it.timestampString)}
-          </div><div>
+        </div>
+        <div>
+          <j:if test="${it.building and it.executor != null}">
+            ${%beingExecuted(it.executor.timestampString)}
+          </j:if>
+        </div>
+        <div>
           <j:if test="${!it.building}">
             ${%Took} <a href="${rootURL}/${it.parent.url}buildTimeTrend">${it.durationString}</a>
           </j:if>

--- a/hudson-core/src/main/resources/hudson/model/AbstractBuild/index.properties
+++ b/hudson-core/src/main/resources/hudson/model/AbstractBuild/index.properties
@@ -21,3 +21,4 @@
 # THE SOFTWARE.
 
 startedAgo=Started {0} ago
+beingExecuted=Build is being executed for {0}


### PR DESCRIPTION
Resolve HUDSON-7926 (Add time execution of the build on build detail page)
http://issues.hudson-ci.org/browse/HUDSON-7926
