### PR TITLE
Androidreport

### DIFF
--- a/hudson-maven-legacy/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
+++ b/hudson-maven-legacy/maven-plugin/src/main/java/hudson/maven/reporters/SurefireArchiver.java
@@ -181,6 +181,7 @@ public class SurefireArchiver extends MavenReporter {
     private boolean isSurefireTest(MojoInfo mojo) {
         if ((!mojo.is("com.sun.maven", "maven-junit-plugin", "test"))
             && (!mojo.is("org.sonatype.flexmojos", "flexmojos-maven-plugin", "test-run"))
+            && (!mojo.is("com.jayway.maven.plugins.android.generation2", "maven-android-plugin", "internal-integration-test"))
             && (!mojo.is("org.apache.maven.plugins", "maven-surefire-plugin", "test"))
             && (!mojo.is("org.apache.maven.plugins", "maven-failsafe-plugin", "integration-test")))
             return false;
@@ -216,13 +217,18 @@ public class SurefireArchiver extends MavenReporter {
                 }
             }
             else if (mojo.is("org.sonatype.flexmojos", "flexmojos-maven-plugin", "test-run")) {
-		Boolean skipTests = mojo.getConfigurationValue("skipTest", Boolean.class);
-		
-		if (((skipTests != null) && (skipTests))) {
-		    return false;
-		}
-	    }
+		        Boolean skipTests = mojo.getConfigurationValue("skipTest", Boolean.class);
 
+                if (((skipTests != null) && (skipTests))) {
+                    return false;
+                }
+            }
+            else if (mojo.is("com.jayway.maven.plugins.android.generation2", "maven-android-plugin", "internal-integration-test")) {
+                Boolean skipTests = mojo.getConfigurationValue("skipTests", Boolean.class);
+                if (((skipTests != null) && (skipTests))) {
+                    return false;
+                }
+            }
         } catch (ComponentConfigurationException e) {
             return false;
         }


### PR DESCRIPTION
I just added support for creating junit compatible reports to the maven android plugin. Works fine with the Maven 3 build step but not with the legacy project type.. so here is a fix for it to work with the legacy project type I got from a community member for Jenkins, with his permission added to Hudson (Richard Mortimer - richm@oldelvet.org.uk - https://github.com/oldelvet)

There are a bunch more hardcoded ones like that in there but I am not sure if we are ok to pull in or even want to bother.. 
