### PR TITLE
HUDSON-9001: NPE when starting Hudson 2.1.1 with --daemon

### DIFF
--- a/hudson-maven3/maven3-plugin/src/main/java/org/hudsonci/maven/plugin/builder/internal/ArtifactRegistry.java
+++ b/hudson-maven3/maven3-plugin/src/main/java/org/hudsonci/maven/plugin/builder/internal/ArtifactRegistry.java
@@ -27,6 +27,8 @@ package org.hudsonci.maven.plugin.builder.internal;
 import com.google.common.collect.ImmutableList;
 import org.hudsonci.maven.model.MavenCoordinatesDTO;
 import org.hudsonci.maven.model.state.ArtifactDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -42,6 +44,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class ArtifactRegistry
 {
+    private static final Logger log = LoggerFactory.getLogger(ArtifactRegistry.class);
+
     // TODO: What's a sane starting point?  Could even size based on the number in the last build.
     // TODO: maybe use ConcurrentMap or javolution FastMap or FastTable; need to time and compare.
     private final Map<MavenCoordinatesDTO,ArtifactDTO> map = new HashMap<MavenCoordinatesDTO,ArtifactDTO>(1000);
@@ -52,8 +56,14 @@ public class ArtifactRegistry
      * Non-null attributes will be overwritten; collection based attributes will have values added.
      */
     public void recordArtifact(final ArtifactDTO artifact) {
-        checkNotNull(artifact);
-        checkNotNull(artifact.getCoordinates());
+        if (artifact == null) {
+            log.warn("Artifact is null");
+            return;
+        }
+        if (artifact.getCoordinates() == null) {
+            log.warn("Artifact coordinates are null");
+            return;
+        }
         
         synchronized (this) {
             ArtifactDTO entry = get(artifact.getCoordinates());

--- a/hudson-war/pom.xml
+++ b/hudson-war/pom.xml
@@ -83,9 +83,28 @@ THE SOFTWARE.
             <goals>
               <goal>list</goal>
             </goals>
-            <!--  TODO: what is actually using this file? -->
+            <!-- used by org.jvnet.hudson:executable-war to find JNA and Akuma versions -->
             <configuration>
               <outputFile>${basedir}/target/classes/dependencies.txt</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>fixDependenciesTxt</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks>
+                <!-- fix Akuma groupId so it can still be found by pre-split org.jvnet.hudson:executable-war:1.17 -->
+                <replace file="${basedir}/target/classes/dependencies.txt" token="org.kohsuke" value="com.sun.akuma"/>
+              </tasks>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
The Main class that drives the executable war (from org.jvnet.hudson:executable-war:1.17) uses the generated dependencies.txt to find the JNA and Akuma versions when started with "--daemon". It expects to find Akuma using the "com.sun.akuma" groupId, but this has been moved to the "org.kohsuke" groupId since version 1.6.

The latest executable-war is more robust and handles relocated artifacts, but also has a hard-coded product name of "Jenkins" in releases since 1.17. Given that this launcher will be replaced as part of the move to Eclipse, the simplest solution is to rename the Akuma groupId in the generated dependencies.txt back to "com.sun.akuma" so it can be found by Main.
