### PR TITLE
Fix HUDSON-8997 (Display node description when hovering on the node name)

### DIFF
--- a/hudson-core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -55,7 +55,7 @@ THE SOFTWARE.
           <td width="32" data="${c.icon}">
             <img src="${imagesURL}/32x32/${c.icon}" width="32" height="32" alt="${c.iconAltText}"/>
           </td>
-          <td><a href="${rootURL}/${c.url}">${c.displayName}</a></td>
+          <td><a href="${rootURL}/${c.url}" title="${c.node!=null? c.node.nodeDescription : ''}">${c.displayName}</a></td>
           <j:forEach var="m" items="${monitors}">
             <j:if test="${m.columnCaption!=null}">
               <j:set var="data" value="${m.data(c)}"/>

--- a/hudson-core/src/main/resources/lib/hudson/executors.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/executors.jelly
@@ -33,7 +33,7 @@ THE SOFTWARE.
   </st:documentation>
   <d:taglib uri="local">
     <d:tag name="computerCaption">
-      <a href="${rootURL}/${c.url}">${title}</a><st:nbsp/>
+      <a href="${rootURL}/${c.url}" title="${c.node!=null? c.node.nodeDescription : ''}">${title}</a><st:nbsp/>
       <j:choose>
         <j:when test="${c.offline}">
           ${%offline}


### PR DESCRIPTION
http://issues.hudson-ci.org/browse/HUDSON-8997
