### PR TITLE
Fixed AxisList comparison

### DIFF
--- a/hudson-core/src/main/java/org/hudsonci/model/project/property/AxisListProjectProperty.java
+++ b/hudson-core/src/main/java/org/hudsonci/model/project/property/AxisListProjectProperty.java
@@ -24,6 +24,10 @@
 package org.hudsonci.model.project.property;
 
 import hudson.matrix.AxisList;
+import hudson.util.DescribableList;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.hudsonci.api.model.IJob;
 
 /**
@@ -42,5 +46,11 @@ public class AxisListProjectProperty extends BaseProjectProperty<AxisList> {
     @Override
     public AxisList getDefaultValue() {
         return new AxisList();
+    }
+    /**
+     * {@inheritDoc}
+     */
+    public boolean allowOverrideValue(AxisList cascadingValue, AxisList candidateValue) {
+        return ObjectUtils.notEqual(cascadingValue, candidateValue);
     }
 }

--- a/hudson-core/src/test/java/org/hudsonci/model/project/property/ProjectPropertyTest.java
+++ b/hudson-core/src/test/java/org/hudsonci/model/project/property/ProjectPropertyTest.java
@@ -390,6 +390,10 @@ public class ProjectPropertyTest {
         assertTrue(property.allowOverrideValue(new AxisList(), null));
         assertTrue(property.allowOverrideValue(null, new AxisList()));
         assertTrue(property.allowOverrideValue(new AxisList().add(new Axis("DB", "mysql")), new AxisList()));
+        assertTrue(property.allowOverrideValue(new AxisList().add(new Axis("DB", "mysql")),
+            new AxisList().add(new Axis("DB", "mysql", "mssql"))));
+        assertTrue(property.allowOverrideValue(new AxisList().add(new Axis("DB", "mysql")),
+            new AxisList().add(new Axis("DB", "mssql"))));
     }
 
     @Test
@@ -400,7 +404,6 @@ public class ProjectPropertyTest {
         assertTrue(property.allowOverrideValue(null, new NullSCM()));
         assertTrue(property.allowOverrideValue(new NullSCM(), new FakeSCM()));
     }
-
 
     /**
      * Verify getCascadingValue method.


### PR DESCRIPTION
Fixed AxisList comparison (EqualsBuilder.reflectionEquals works incorrectly in this case).
