### PR TITLE
HUDSON-9064: avoid UnsupportedOperationException on JBoss5

### DIFF
--- a/hudson-core/src/main/java/hudson/ProxyConfiguration.java
+++ b/hudson-core/src/main/java/hudson/ProxyConfiguration.java
@@ -136,7 +136,7 @@ public final class ProxyConfiguration implements Saveable {
          
         
         if(proxyConfig == null){
-            return url.openConnection(Proxy.NO_PROXY);
+            return url.openConnection();
         }
         
         if (proxyConfig.noProxyFor != null){


### PR DESCRIPTION
The custom URLStreamHandlers from JBoss5 do not provide an implementation of the openConnection(proxy) method introduced in Java5 - any call to url.openConnection(proxy) will throw UnsupportedOperationException.

Commit f4fc4cdd in hudson-core/src/main/java/hudson/ProxyConfiguration.java changed the default call when no proxy configuration exists from url.openConnection() to url.openConnection(proxy). This leads to exceptions during startup on JBoss5 when the maven3 slavebundle is installed.

This pull request changes the default call back to the original url.openConnection() - note that I did consider putting a try-catch block around the url.openConnection(proxy) call to fall back to url.openConnection() only when UnsupportedOperationException occurred but considered that was overkill, since those methods should behave the same for the no proxy configuration case.
