### PR TITLE
Resolve HUDSON-9072 (500 Exception adding a slave axis to a matrix build in IE8): Fix IE JS specific name attribute handling. Small javaDoc fix.

### DIFF
--- a/hudson-core/src/main/java/hudson/util/CascadingUtil.java
+++ b/hudson-core/src/main/java/hudson/util/CascadingUtil.java
@@ -528,7 +528,7 @@ public class CascadingUtil {
      * As for {@link ParametersDefinitionProperty} single instance doesn't support cascading, so, classes are
      * grouped into list of {@link ParametersDefinitionProperty} and whole list could be inherited or overridden.
 
-     * * @param d property descriptor.
+     * @param d property descriptor.
      * @return true - if JobProperty could be used for cascading, false - otherwise.
      * @see #setParameterDefinitionProperties(hudson.model.Job, String, CopyOnWriteList)
      * @see hudson.model.Job#getParameterDefinitionProperties()

--- a/hudson-war/src/main/webapp/scripts/hudson-behavior.js
+++ b/hudson-war/src/main/webapp/scripts/hudson-behavior.js
@@ -1658,7 +1658,7 @@ function findFormParent(e,form,static) {
             return null;  // this field shouldn't contribute to the final result
 
         var name = e.getAttribute("name");
-        if(name!=null) {
+        if(name!=null && name!='') {
             if(e.tagName=="INPUT" && !static && !xor(e.checked,Element.hasClassName(e,"negative")))
                 return null;  // field is not active
 


### PR DESCRIPTION
http://issues.hudson-ci.org/browse/HUDSON-9072
