### PR TITLE
Add null check for Describable#toMap method. Avoid NPE and fix HUDSON-9067

### DIFF
--- a/hudson-core/src/main/java/hudson/model/Descriptor.java
+++ b/hudson-core/src/main/java/hudson/model/Descriptor.java
@@ -767,8 +767,10 @@ public abstract class Descriptor<T extends Describable<T>> implements Saveable {
     public static <T extends Describable<T>>
     Map<Descriptor<T>,T> toMap(Iterable<T> describables) {
         Map<Descriptor<T>,T> m = new LinkedHashMap<Descriptor<T>,T>();
-        for (T d : describables) {
-            m.put(d.getDescriptor(),d);
+        if (null != describables) {
+            for (T d : describables) {
+                m.put(d.getDescriptor(), d);
+            }
         }
         return m;
     }


### PR DESCRIPTION
http://issues.hudson-ci.org/browse/HUDSON-9067
