### PR TITLE
Use staged 2.2.0 release of maven-plugin, maven3-plugin, and maven3-snapshots

### DIFF
--- a/hudson-plugin-parent/pom.xml
+++ b/hudson-plugin-parent/pom.xml
@@ -43,7 +43,7 @@ THE SOFTWARE.
     <java.net.id>${user.name}</java.net.id>
 
     <rest-plugin.version>2.1.2</rest-plugin.version>
-    <maven-plugin.version>2.2.0-SNAPSHOT</maven-plugin.version>
+    <maven-plugin.version>2.2.0</maven-plugin.version>
     <hudson-war.version>2.2.0-SNAPSHOT</hudson-war.version>
     <hudson-core.version>2.2.0-SNAPSHOT</hudson-core.version>
     <hudson-test-framework.version>2.2.0-SNAPSHOT</hudson-test-framework.version>

--- a/hudson-test-framework/pom.xml
+++ b/hudson-test-framework/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.jvnet.hudson.main</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>2.2.0-SNAPSHOT</version>
+      <version>2.2.0</version>
     </dependency>
 
     <dependency>

--- a/hudson-war/pom.xml
+++ b/hudson-war/pom.xml
@@ -155,9 +155,9 @@ THE SOFTWARE.
                 
                 <!-- bundled plugins -->
                 <resolveArtifact type="hpi" groupId="${project.groupId}" artifactId="rest-plugin" version="2.1.2" tofile="${basedir}/target/generated-resources/WEB-INF/plugins/rest-plugin.hpi" />
-                <resolveArtifact type="hpi" groupId="${project.groupId}" artifactId="maven3-plugin" version="2.2.0-SNAPSHOT" tofile="${basedir}/target/generated-resources/WEB-INF/plugins/maven3-plugin.hpi" />
-                <resolveArtifact type="hpi" groupId="${project.groupId}" artifactId="maven3-snapshots" version="2.2.0-SNAPSHOT" tofile="${basedir}/target/generated-resources/WEB-INF/plugins/maven3-snapshots.hpi" />
-                <resolveArtifact type="hpi" groupId="${project.groupId}" artifactId="maven-plugin" version="2.2.0-SNAPSHOT" tofile="${basedir}/target/generated-resources/WEB-INF/plugins/maven-plugin.hpi" />
+                <resolveArtifact type="hpi" groupId="${project.groupId}" artifactId="maven3-plugin" version="2.2.0" tofile="${basedir}/target/generated-resources/WEB-INF/plugins/maven3-plugin.hpi" />
+                <resolveArtifact type="hpi" groupId="${project.groupId}" artifactId="maven3-snapshots" version="2.2.0" tofile="${basedir}/target/generated-resources/WEB-INF/plugins/maven3-snapshots.hpi" />
+                <resolveArtifact type="hpi" groupId="${project.groupId}" artifactId="maven-plugin" version="2.2.0" tofile="${basedir}/target/generated-resources/WEB-INF/plugins/maven-plugin.hpi" />
                 <resolveArtifact type="hpi" groupId="org.hudsonci.plugins" artifactId="ssh-slaves" version="2.1.1" tofile="${basedir}/target/generated-resources/WEB-INF/plugins/ssh-slaves.hpi" />
                 <resolveArtifact type="hpi" groupId="org.hudsonci.plugins" artifactId="subversion" version="2.2.0_1" tofile="${basedir}/target/generated-resources/WEB-INF/plugins/subversion.hpi" />
                 <resolveArtifact type="hpi" groupId="org.hudsonci.plugins" artifactId="cvs" version="2.2.0" tofile="${basedir}/target/generated-resources/WEB-INF/plugins/cvs.hpi" />
@@ -293,20 +293,20 @@ THE SOFTWARE.
     <dependency>
       <groupId>org.jvnet.hudson.main</groupId>
       <artifactId>maven3-plugin</artifactId>
-      <version>2.1.2</version>
+      <version>2.2.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson.main</groupId>
       <artifactId>maven3-snapshots</artifactId>
-      <version>2.1.2</version>
+      <version>2.2.0</version>
       <scope>provided</scope>
     </dependency>
     <!-- REMOVE when the legacy maven-plugin isn't a bundled plugin -->
     <dependency>
       <groupId>org.jvnet.hudson.main</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>2.2.0-SNAPSHOT</version>
+      <version>2.2.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@ THE SOFTWARE.
                   <plugin>
                     <groupId>org.jvnet.hudson.main</groupId>
                     <artifactId>hudson-jaxb-xjc</artifactId>
-                    <version>${project.version}</version>
+                    <version>2.1.2</version>
                   </plugin>
                 </plugins>
               </configuration>


### PR DESCRIPTION
The maven-plugin 2.2.0 release is currently staged under:

   https://oss.sonatype.org/content/repositories/orgjvnethudson-037/

and the maven3-plugin + maven3-snapshots 2.2.0 release is staged under:

   https://oss.sonatype.org/content/repositories/orgjvnethudson-039/
