### PR TITLE
Enable escaping by default in core jelly files

### DIFF
--- a/hudson-core/src/main/java/hudson/Functions.java
+++ b/hudson-core/src/main/java/hudson/Functions.java
@@ -128,6 +128,7 @@ import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerProxy;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.jelly.InternationalizedStringExpression;
 
 /**
  * Utility functions used in views.
@@ -541,6 +542,10 @@ public class Functions {
 
     public static String xmlEscape(String s) {
         return Util.xmlEscape(s);
+    }
+
+    public static String xmlUnescape(String s) {
+        return s.replace("&lt;","<").replace("&gt;",">").replace("&amp;","&");
     }
 
     public static void checkPermission(Permission permission) throws IOException, ServletException {
@@ -1389,4 +1394,7 @@ public class Functions {
         return templates.iterator().hasNext() ? templates.iterator().next() : null;
     }
 
+    public static Object rawHtml(Object o) {
+        return InternationalizedStringExpression.rawHtml(o);
+    }
 }

--- a/hudson-core/src/main/resources/hudson/PluginManager/advanced.jelly
+++ b/hudson-core/src/main/resources/hudson/PluginManager/advanced.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   List of available new plugins
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <l:layout title="Update Center" permission="${app.ADMINISTER}" norefresh="true">
   <st:include page="sidepanel.jelly"/>

--- a/hudson-core/src/main/resources/hudson/PluginManager/available.jelly
+++ b/hudson-core/src/main/resources/hudson/PluginManager/available.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   List of available new plugins    
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <local:table page="available" list="${app.updateCenter.categorizedAvailables}" xmlns:local="/hudson/PluginManager" />
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/PluginManager/checkUpdates.jelly
+++ b/hudson-core/src/main/resources/hudson/PluginManager/checkUpdates.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Forcibly check updates
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <l:layout title="Update Center" permission="${app.ADMINISTER}" forcedUpdateCheck="true" norefresh="true">
   <st:include page="sidepanel.jelly"/>

--- a/hudson-core/src/main/resources/hudson/PluginManager/index.jelly
+++ b/hudson-core/src/main/resources/hudson/PluginManager/index.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Update Center main page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <local:table page="updates" list="${app.updateCenter.updates}" xmlns:local="/hudson/PluginManager">
     <div style="margin-top:1em">

--- a/hudson-core/src/main/resources/hudson/PluginManager/installed.jelly
+++ b/hudson-core/src/main/resources/hudson/PluginManager/installed.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:layout title="Update Center" permission="${app.ADMINISTER}" norefresh="true">
     <st:include page="sidepanel.jelly"/>

--- a/hudson-core/src/main/resources/hudson/PluginManager/sidepanel.jelly
+++ b/hudson-core/src/main/resources/hudson/PluginManager/sidepanel.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Side panel
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:header />
   <l:side-panel>

--- a/hudson-core/src/main/resources/hudson/PluginManager/sites.jelly
+++ b/hudson-core/src/main/resources/hudson/PluginManager/sites.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Add/remove update center sites
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <l:layout title="Update Center" permission="${app.ADMINISTER}" norefresh="true">
   <st:include page="sidepanel.jelly"/>

--- a/hudson-core/src/main/resources/hudson/PluginManager/tabBar.jelly
+++ b/hudson-core/src/main/resources/hudson/PluginManager/tabBar.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   List of available new plugins
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:tabBar>
     <l:tab name="${%Updates}" active="${page=='updates'}" href="." />

--- a/hudson-core/src/main/resources/hudson/PluginManager/table.jelly
+++ b/hudson-core/src/main/resources/hudson/PluginManager/table.jelly
@@ -29,6 +29,7 @@ THE SOFTWARE.
      list: variable to contain List<Plugin>
      page: page name to be passed to local:tabBar
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout title="Update Center" permission="${app.ADMINISTER}" norefresh="true">
     <st:include page="sidepanel.jelly"/>
@@ -98,7 +99,7 @@ THE SOFTWARE.
                         <a href="${p.wiki}"><st:out value="${p.displayName}"/></a>
                       </div>
                       <j:if test="${p.excerpt!=null}">
-                        <div class="excerpt">${p.excerpt}</div>
+                        <div class="excerpt"><j:out value="${app.markupFormatter.translate(p.excerpt)}" /></div>
                       </j:if>
                       <j:if test="${!p.isCompatibleWithInstalledVersion()}">
                         <div class="compatWarning">${%compatWarning}</div>

--- a/hudson-core/src/main/resources/hudson/SystemQuietingDownGlobalMessage/detail.jelly
+++ b/hudson-core/src/main/resources/hudson/SystemQuietingDownGlobalMessage/detail.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
   <div id='shutdown-msg'>Hudson is preparing to shutdown</div>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
+++ b/hudson-core/src/main/resources/hudson/TcpSlaveAgentListener/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <!--
     Publicize the TCP port number for JNLP slave agents so that they know where to conenct.

--- a/hudson-core/src/main/resources/hudson/atom.jelly
+++ b/hudson-core/src/main/resources/hudson/atom.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"><!-- No whitespace before xml header: -->&lt;?xml version="1.0" encoding="UTF-8"?&gt;
   <st:contentType value="application/atom+xml;charset=UTF-8" />
   <j:new var="h" className="hudson.Functions" /><!-- instead of JSP functions -->
@@ -46,14 +47,14 @@ THE SOFTWARE.
 
     <j:forEach var="e" items="${entries}" >
       <entry>
-        <title>${h.xmlEscape(adapter.getEntryTitle(e))}</title>
+        <title>${adapter.getEntryTitle(e)}</title>
         <link rel="alternate" type="text/html" href="${rootURL}${h.encode(adapter.getEntryUrl(e))}"/>
         <id>${adapter.getEntryID(e)}</id>
         <published>${h.xsDate(adapter.getEntryTimestamp(e))}</published>
         <updated>${h.xsDate(adapter.getEntryTimestamp(e))}</updated>
         <j:set var="desc" value="${adapter.getEntryDescription(e)}"/>
         <j:if test="${desc!=null}">
-          <content>${h.xmlEscape(desc)}</content>
+          <content>${desc}</content>
         </j:if>
       </entry>
     </j:forEach>

--- a/hudson-core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.jelly
+++ b/hudson-core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 	<l:layout title="${%HUDSON_HOME is almost full}">
 		<l:main-panel>

--- a/hudson-core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/message.jelly
+++ b/hudson-core/src/main/resources/hudson/diagnosis/HudsonHomeDiskUsageMonitor/message.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">

--- a/hudson-core/src/main/resources/hudson/diagnosis/MemoryUsageMonitor/index.jelly
+++ b/hudson-core/src/main/resources/hudson/diagnosis/MemoryUsageMonitor/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName} Memory Usage">
     <!-- TODO: where in the tree structure should this really belong? -->

--- a/hudson-core/src/main/resources/hudson/diagnosis/OldDataMonitor/manage.jelly
+++ b/hudson-core/src/main/resources/hudson/diagnosis/OldDataMonitor/manage.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <l:layout title="${%Manage Old Data}" permission="${app.ADMINISTER}">
   <st:include page="sidepanel.jelly" it="${app}"/>

--- a/hudson-core/src/main/resources/hudson/diagnosis/OldDataMonitor/message.jelly
+++ b/hudson-core/src/main/resources/hudson/diagnosis/OldDataMonitor/message.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">

--- a/hudson-core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
+++ b/hudson-core/src/main/resources/hudson/diagnosis/ReverseProxySetupMonitor/message.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <script>
     var checkAjax=new Ajax.Request('${rootURL}/${it.url}/test', {

--- a/hudson-core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
+++ b/hudson-core/src/main/resources/hudson/diagnosis/TooManyJobsButNoView/message.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="warning">
     <form method="post" action="${rootURL}/${it.url}/act" name="${it.id}">

--- a/hudson-core/src/main/resources/hudson/lifecycle/WindowsInstallerLink/_restart.jelly
+++ b/hudson-core/src/main/resources/hudson/lifecycle/WindowsInstallerLink/_restart.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:statusCode value="503" /><!-- SERVICE NOT AVAILABLE -->
   <l:layout permission="${app.ADMINISTER}">

--- a/hudson-core/src/main/resources/hudson/lifecycle/WindowsInstallerLink/index.jelly
+++ b/hudson-core/src/main/resources/hudson/lifecycle/WindowsInstallerLink/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout permission="${app.ADMINISTER}" title="${%Install as Windows Service}">
     <st:include it="${app}" page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/logging/LogRecorder/configure.jelly
+++ b/hudson-core/src/main/resources/hudson/logging/LogRecorder/configure.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <l:layout norefresh="true">
   <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/logging/LogRecorder/delete.jelly
+++ b/hudson-core/src/main/resources/hudson/logging/LogRecorder/delete.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Displays the button to delete the build.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/logging/LogRecorder/deleteConfirmationPanel.jelly
+++ b/hudson-core/src/main/resources/hudson/logging/LogRecorder/deleteConfirmationPanel.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <div>
     <form method="post" action="doDelete">
         <h4>${%Are you sure about deleting the log recorder?}</h4>

--- a/hudson-core/src/main/resources/hudson/logging/LogRecorder/index.jelly
+++ b/hudson-core/src/main/resources/hudson/logging/LogRecorder/index.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Log view
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <l:layout title="Log" permission="${app.ADMINISTER}">
   <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/logging/LogRecorder/sidepanel.jelly
+++ b/hudson-core/src/main/resources/hudson/logging/LogRecorder/sidepanel.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Side panel for the log recorder
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:header />
   <l:side-panel>

--- a/hudson-core/src/main/resources/hudson/logging/LogRecorderManager/all.jelly
+++ b/hudson-core/src/main/resources/hudson/logging/LogRecorderManager/all.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Show all hudson.* logs
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <l:layout title="Log">
   <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/logging/LogRecorderManager/feeds.jelly
+++ b/hudson-core/src/main/resources/hudson/logging/LogRecorderManager/feeds.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- list of feed links -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div align="right" style="margin:1em">
     <img src="${imagesURL}/atom.gif" border="0" alt="Feed"/>

--- a/hudson-core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
+++ b/hudson-core/src/main/resources/hudson/logging/LogRecorderManager/index.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Log view
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <l:layout title="${%Log}">
   <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/logging/LogRecorderManager/levels.jelly
+++ b/hudson-core/src/main/resources/hudson/logging/LogRecorderManager/levels.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Show form to adjust log levels
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <l:layout title="Log Levels">
   <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/logging/LogRecorderManager/new.jelly
+++ b/hudson-core/src/main/resources/hudson/logging/LogRecorderManager/new.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Create a new LogRecorder
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/logging/LogRecorderManager/sidepanel.jelly
+++ b/hudson-core/src/main/resources/hudson/logging/LogRecorderManager/sidepanel.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Side panel
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:header />
   <l:side-panel>

--- a/hudson-core/src/main/resources/hudson/markup/RawHtmlMarkupFormatter/config.jelly
+++ b/hudson-core/src/main/resources/hudson/markup/RawHtmlMarkupFormatter/config.jelly
@@ -1,4 +1,5 @@
 <!-- no config -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:description>
     ${%blurb}

--- a/hudson-core/src/main/resources/hudson/model/AbstractBuild/changes.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractBuild/changes.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Displays the console output
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.fullDisplayName} ${%Changes}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/AbstractBuild/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractBuild/index.jelly
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.fullDisplayName}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/AbstractBuild/sidepanel.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractBuild/sidepanel.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Side panel for the build view.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:header />
   <l:side-panel>

--- a/hudson-core/src/main/resources/hudson/model/AbstractBuild/tasks.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractBuild/tasks.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Side panel for the build view.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
       <l:task icon="images/24x24/up.gif" href="${it.upUrl}" title="${%Back to Project}" />
       <l:task icon="images/24x24/search.gif" href="${buildUrl.baseUrl}/" title="${%Status}" />

--- a/hudson-core/src/main/resources/hudson/model/AbstractItem/configure-common.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractItem/configure-common.jelly
@@ -26,6 +26,7 @@ THE SOFTWARE.
 <!--
   Parts of the configuration that applies to Project and MavenModuleSet.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project" xmlns:this="this">
     <p:config-disableBuild/>

--- a/hudson-core/src/main/resources/hudson/model/AbstractItem/delete.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractItem/delete.jelly
@@ -28,6 +28,7 @@ THE SOFTWARE.
   Some jobs cannot be deleted by the user, so this view is not necessarily
   applicable to all jobs.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
 		<st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/AbstractModelObject/descriptionForm.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractModelObject/descriptionForm.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Used by editableDescription.jelly for loading the edit form.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:l="/lib/layout">
   <j:if test="${it.class.name=='hudson.model.Hudson'}">
     <j:set var="it" value="${it.primaryView}"/>

--- a/hudson-core/src/main/resources/hudson/model/AbstractModelObject/editDescription.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractModelObject/editDescription.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   If JavaScript is off, this form is used to edit the description
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName}" norefresh="true">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/AbstractModelObject/error.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractModelObject/error.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <st:statusCode value="400" /><!-- clearly indicate that this page is an error page --> 
   <l:layout title="Hudson">

--- a/hudson-core/src/main/resources/hudson/model/AbstractProject/BecauseOfUpstreamBuildInProgress/summary.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractProject/BecauseOfUpstreamBuildInProgress/summary.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <st:structuredMessageFormat key="description">
     <st:structuredMessageArgument>

--- a/hudson-core/src/main/resources/hudson/model/AbstractProject/_api.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractProject/_api.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <st:include page="/hudson/model/Job/_api.jelly" />
 

--- a/hudson-core/src/main/resources/hudson/model/AbstractProject/changes.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractProject/changes.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Displays the console output
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${%changes.title(it.name)}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/AbstractProject/delete.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractProject/delete.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/AbstractProject/deleteConfirmationPanel.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractProject/deleteConfirmationPanel.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <l:jobDeleteForm />
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/AbstractProject/main.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractProject/main.jelly
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
   <p:projectActionFloatingBox />
 

--- a/hudson-core/src/main/resources/hudson/model/AbstractProject/noWorkspace.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractProject/noWorkspace.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- tell user that there's no workspace yet -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/AbstractProject/sidepanel.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractProject/sidepanel.jelly
@@ -26,6 +26,7 @@ THE SOFTWARE.
 <!--
   Side panel for the project view.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:header title="${it.name}">
     <st:include page="rssHeader.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/AbstractProject/svn-password.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractProject/svn-password.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- show the icon legend -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/AbstractProject/wipeOutWorkspace.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractProject/wipeOutWorkspace.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- ask the user if he's ready to wipe out the workspace -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/AbstractProject/wipeOutWorkspaceBlocked.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AbstractProject/wipeOutWorkspaceBlocked.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- tell user that there's no workspace yet -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Actionable/actions.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Actionable/actions.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Action list
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <t:actions />
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/AgentSlave/config.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AgentSlave/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<f:entry title="${%launch command}">
 	  <f:textbox name="slave.command" value="${slave.command}"/>

--- a/hudson-core/src/main/resources/hudson/model/AllView/newViewDetail.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AllView/newViewDetail.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <div>
   ${%blurb}
 </div>

--- a/hudson-core/src/main/resources/hudson/model/AllView/noJob.jelly
+++ b/hudson-core/src/main/resources/hudson/model/AllView/noJob.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <div>
   <!--
     This is a good place to add "welcome" materials, like pointers to the website and etc

--- a/hudson-core/src/main/resources/hudson/model/Api/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Api/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 	<l:layout title="Remote API">
 		<l:main-panel>

--- a/hudson-core/src/main/resources/hudson/model/BooleanParameterDefinition/config.jelly
+++ b/hudson-core/src/main/resources/hudson/model/BooleanParameterDefinition/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">

--- a/hudson-core/src/main/resources/hudson/model/BooleanParameterDefinition/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/BooleanParameterDefinition/index.jelly
@@ -22,10 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<f:entry title="${it.name}" description="${it.description}">
+	<f:entry title="${it.name!=null ? app.markupFormatter.translate(it.name) : ''}"
+	   description="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}">
 		<div name="parameter" description="${it.description}">
 			<input type="hidden" name="name" value="${it.name}" />
 			<f:checkbox name="value" checked="${it.defaultValue}" />

--- a/hudson-core/src/main/resources/hudson/model/BooleanParameterValue/value.jelly
+++ b/hudson-core/src/main/resources/hudson/model/BooleanParameterValue/value.jelly
@@ -22,10 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<f:entry title="${it.name}" description="${it.description}">
+	<f:entry title="${it.name!=null ? app.markupFormatter.translate(it.name) : ''}"
+	   description="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}">
 		<f:checkbox name="value" checked="${it.value}" readonly="true" />
 	</f:entry>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/BuildAuthorizationToken/config.jelly
+++ b/hudson-core/src/main/resources/hudson/model/BuildAuthorizationToken/config.jelly
@@ -27,6 +27,7 @@ THE SOFTWARE.
   Pseudo trigger configuration.
   Note that it is the object that owns BuildAuthorizationToken
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:if test="${app.useSecurity}">
     <f:optionalBlock name="pseudoRemoteTrigger"

--- a/hudson-core/src/main/resources/hudson/model/BuildTimelineWidget/control.jelly
+++ b/hudson-core/src/main/resources/hudson/model/BuildTimelineWidget/control.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <st:documentation>
     Show timeline trend image. It takes two builds

--- a/hudson-core/src/main/resources/hudson/model/Cause/UpstreamCause/description.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Cause/UpstreamCause/description.jelly
@@ -21,7 +21,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <!-- upstreamUrl added in 1.284, so handle missing value -->
-    <span>${it.upstreamUrl!=null ? "%started_by_project(it.upstreamProject,it.upstreamBuild.toString(),it.upstreamUrl,rootURL)" : it.shortDescription}</span>
+    <span><j:out value='${it.upstreamUrl!=null ? "%started_by_project(it.upstreamProject,it.upstreamBuild.toString(),it.upstreamUrl,rootURL)" : it.shortDescription}' /></span>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/Cause/UserCause/description.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Cause/UserCause/description.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <span>${%started_by_user(it.userName,rootURL)}</span>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/Cause/description.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Cause/description.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <span>${it.shortDescription}</span>
+    <span><j:out value="${it.shortDescription}" /></span>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/CauseAction/summary.jelly
+++ b/hudson-core/src/main/resources/hudson/model/CauseAction/summary.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <t:summary icon="orange-square.gif">
     <j:forEach var="entry" items="${it.causeCounts.entrySet()}">

--- a/hudson-core/src/main/resources/hudson/model/ChoiceParameterDefinition/config.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ChoiceParameterDefinition/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">

--- a/hudson-core/src/main/resources/hudson/model/ChoiceParameterDefinition/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ChoiceParameterDefinition/index.jelly
@@ -22,10 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<f:entry title="${it.name}" description="${it.description}">
+	<f:entry title="${it.name!=null ? app.markupFormatter.translate(it.name) : ''}"
+	   description="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}">
 		<div name="parameter" description="${it.description}">
 			<input type="hidden" name="name" value="${it.name}" />
             <select name="value">

--- a/hudson-core/src/main/resources/hudson/model/Computer/_api.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Computer/_api.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <h2>Load Statistics</h2>
   <p>

--- a/hudson-core/src/main/resources/hudson/model/Computer/_script.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Computer/_script.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Called from doScript() to display the execution result and the form.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <t:scriptConsole>
     <pre>println System.getenv("PATH")</pre>

--- a/hudson-core/src/main/resources/hudson/model/Computer/_scriptText.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Computer/_scriptText.jelly
@@ -25,5 +25,6 @@ THE SOFTWARE.
 <!--
   Called from doScriptText() to display the execution result.
 -->
+<?jelly escape-by-default='false'?>
 <st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler">
 <st:contentType value="text/plain;charset=UTF-8" />${output}</st:compress>

--- a/hudson-core/src/main/resources/hudson/model/Computer/ajaxExecutors.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Computer/ajaxExecutors.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Used to asynchronously update executor queue
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:ajax>
     <t:executors computers="${h.singletonList(it)}" />

--- a/hudson-core/src/main/resources/hudson/model/Computer/builds.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Computer/builds.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Computer/configure.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Computer/configure.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true" permission="${it.CONFIGURE}" title="${%title(it.displayName)}">

--- a/hudson-core/src/main/resources/hudson/model/Computer/custom-jnlp.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Computer/custom-jnlp.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Computer/delete.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Computer/delete.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
 		<st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Computer/deleteConfirmationPanel.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Computer/deleteConfirmationPanel.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <script type="text/javascript">
         function deletingSlave() {

--- a/hudson-core/src/main/resources/hudson/model/Computer/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Computer/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Computer/load-statistics.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Computer/load-statistics.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName} Load Statistics">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Computer/markOffline.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Computer/markOffline.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${%title(it.displayName)}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Computer/nodepropertysummaries.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Computer/nodepropertysummaries.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- display permalinks of the page -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
 	<!-- give properties a chance to contribute summary item -->
 	<j:forEach var="p" items="${app.globalNodeProperties}">

--- a/hudson-core/src/main/resources/hudson/model/Computer/sidepanel.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Computer/sidepanel.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Side panel for a slave.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:header />
   <l:side-panel>

--- a/hudson-core/src/main/resources/hudson/model/ComputerSet/_new.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ComputerSet/_new.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   2nd page in the "new slave" page for displaying the entire configuration entries for the selected job type.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true" permission="${app.ADMINISTER}">

--- a/hudson-core/src/main/resources/hudson/model/ComputerSet/configure.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ComputerSet/configure.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Manage monitoring
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${%Node Monitoring Configuration}" norefresh="true">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/ComputerSet/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ComputerSet/index.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Entrance to the configuration page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
 <l:layout title="Nodes">
   <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/ComputerSet/new.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ComputerSet/new.jelly
@@ -29,6 +29,7 @@ THE SOFTWARE.
 
     new.jelly -> ComputerSet.doCreateItem -> _new2.jelly -> ComputerSet.doDoCreateItem
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:layout norefresh="true" permission="${app.ADMINISTER}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/ComputerSet/sidepanel.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ComputerSet/sidepanel.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Side panel
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:header />
   <l:side-panel>

--- a/hudson-core/src/main/resources/hudson/model/Descriptor/newInstanceDetail.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Descriptor/newInstanceDetail.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <!--
     Used to render the description under a radio button in the "new job/computer/etc" page.

--- a/hudson-core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
+++ b/hudson-core/src/main/resources/hudson/model/DirectoryBrowserSupport/dir.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- Show files in the workspace -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.title} : ${path}">
     <st:include page="sidepanel.jelly" it="${it.owner}"/>
@@ -33,7 +34,7 @@ THE SOFTWARE.
           <form action="${backPath}" method="get">
             <a href="${topPath}"><img src="${imagesURL}/48x48/${icon}" class="rootIcon" alt=""/></a>
             <j:forEach var="p" items="${parentPath}">
-              <a href="${p.href}">${h.xmlEscape(p.title)}</a>
+              <a href="${p.href}">${p.title}</a>
               /
             </j:forEach>
             <input type="text" name="pattern" value="${pattern}" />
@@ -58,10 +59,10 @@ THE SOFTWARE.
                     
                       <j:choose>
                         <j:when test="${x.readable}">
-                          <a href="${t.href}">${h.xmlEscape(t.title)}</a>
+                          <a href="${t.href}">${t.title}</a>
                         </j:when>
                         <j:otherwise>
-                          ${h.xmlEscape(t.title)}
+                          ${t.title}
                         </j:otherwise>
                       </j:choose>
                       

--- a/hudson-core/src/main/resources/hudson/model/DownloadService/footer.jelly
+++ b/hudson-core/src/main/resources/hudson/model/DownloadService/footer.jelly
@@ -29,6 +29,7 @@ THE SOFTWARE.
 
   This file is pulled into the layout.jelly
 -->
+<?jelly escape-by-default='false'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   ${it.generateFragment()}
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/Executor/causeOfDeath.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Executor/causeOfDeath.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.name}">
     <l:header />

--- a/hudson-core/src/main/resources/hudson/model/ExternalJob/deleteConfirmationPanel.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ExternalJob/deleteConfirmationPanel.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <l:jobDeleteForm />
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/ExternalJob/newJobDetail.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ExternalJob/newJobDetail.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <div>
   ${%body}
 </div>

--- a/hudson-core/src/main/resources/hudson/model/ExternalJob/sidepanel.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ExternalJob/sidepanel.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Side panel for the build view.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 	<l:header title="${it.name}">
 	  <st:include page="rssHeader.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/ExternalRun/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ExternalRun/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 	<st:include page="console.jelly"/>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/ExternalRun/sidepanel.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ExternalRun/sidepanel.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Side panel for the build view.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:header title="${it.fullDisplayName}" />
   <l:side-panel>

--- a/hudson-core/src/main/resources/hudson/model/FileParameterDefinition/config.jelly
+++ b/hudson-core/src/main/resources/hudson/model/FileParameterDefinition/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">

--- a/hudson-core/src/main/resources/hudson/model/FileParameterDefinition/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/FileParameterDefinition/index.jelly
@@ -22,10 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<f:entry title="${it.name}" description="${it.description}">
+	<f:entry title="${it.name!=null ? app.markupFormatter.translate(it.name) : ''}"
+	   description="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}">
 		<div name="parameter">
 			<input type="hidden" name="name" value="${it.name}" />
 			<input name="file" type="file" jsonAware="true" />

--- a/hudson-core/src/main/resources/hudson/model/FileParameterValue/value.jelly
+++ b/hudson-core/src/main/resources/hudson/model/FileParameterValue/value.jelly
@@ -22,10 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-    <f:entry title="${it.name}">
+    <f:entry title="${it.name!=null ? app.markupFormatter.translate(it.name) : ''}"
+       description="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}">
         <j:if test="${it.originalFileName != null}">
             <j:invokeStatic var="encodedName" className="hudson.Util" method="rawEncode">
                 <j:arg value="${it.name}" />

--- a/hudson-core/src/main/resources/hudson/model/Fingerprint/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Fingerprint/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <l:header title="${it.fileName}">

--- a/hudson-core/src/main/resources/hudson/model/FreeStyleProject/configure-advanced.jelly
+++ b/hudson-core/src/main/resources/hudson/model/FreeStyleProject/configure-advanced.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Additional entries in the advanced section.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project">
   <p:config-customWorkspace />
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/FreeStyleProject/newJobDetail.jelly
+++ b/hudson-core/src/main/resources/hudson/model/FreeStyleProject/newJobDetail.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <div>
   ${%body}
 </div>

--- a/hudson-core/src/main/resources/hudson/model/Hudson/_api.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/_api.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <h2>Create Job</h2>
   <p>

--- a/hudson-core/src/main/resources/hudson/model/Hudson/_cli.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/_cli.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout norefresh="true">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Hudson/_restart.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/_restart.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- Delete view -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 	<l:layout title="Restart Hudson">
 		<st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Hudson/_safeRestart.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/_safeRestart.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- Delete view -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 	<l:layout title="Safely Restart Hudson">
 		<st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Hudson/_script.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/_script.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Called from doScript() to display the execution result and the form.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <t:scriptConsole>
     <pre>println(hudson.model.Hudson.instance.pluginManager.plugins)</pre>

--- a/hudson-core/src/main/resources/hudson/model/Hudson/_scriptText.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/_scriptText.jelly
@@ -25,5 +25,6 @@ THE SOFTWARE.
 <!--
   Called from doScriptText() to display the execution result.
 -->
+<?jelly escape-by-default='false'?>
 <st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler">
 <st:contentType value="text/plain;charset=UTF-8" />${output}</st:compress>

--- a/hudson-core/src/main/resources/hudson/model/Hudson/accessDenied.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/accessDenied.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true">
     <!-- don't include sidepanel.jelly, which could reveal information -->

--- a/hudson-core/src/main/resources/hudson/model/Hudson/configureExecutors.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/configureExecutors.jelly
@@ -26,6 +26,7 @@ THE SOFTWARE.
   This used to be where people configure executors before 1.271, so just in case people have bookmarked this page,
   explain what happened.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <l:layout title="This page has moved">
   <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Hudson/downgrade.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/downgrade.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="downgrade">
       <j:if test="${app.updateCenter.downgradable}">

--- a/hudson-core/src/main/resources/hudson/model/Hudson/fingerprintCheck.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/fingerprintCheck.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   New View page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Hudson/legend.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/legend.jelly
@@ -24,6 +24,7 @@ THE SOFTWARE.
 -->
 
 <!-- show the icon legend -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:layout>
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Hudson/load-statistics.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/load-statistics.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName} Load Statistics">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Hudson/login.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/login.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true">
     <l:hasPermission permission="${app.READ}">

--- a/hudson-core/src/main/resources/hudson/model/Hudson/loginError.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/loginError.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- report a login error -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:choose>
     <j:new var="h" className="hudson.Functions" />

--- a/hudson-core/src/main/resources/hudson/model/Hudson/manage.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/manage.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Entrance to the configuration page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <l:layout title="${%Manage Hudson}" xmlns:local="local" permission="${app.ADMINISTER}">
   <d:taglib uri="local">
@@ -101,7 +102,7 @@ THE SOFTWARE.
       <j:forEach var="m" items="${it.managementLinks}">
         <j:if test="${m.iconFileName!=null}">
           <local:feature icon="${m.iconFileName}"      href="${m.urlName}"   title="${m.displayName}">
-            ${m.description}
+            <j:out value="${m.description}"/>
           </local:feature>
         </j:if>
       </j:forEach>

--- a/hudson-core/src/main/resources/hudson/model/Hudson/newView.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/newView.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   New View page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true" permission="${app.primaryView.CREATE}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Hudson/noPrincipal.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/noPrincipal.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- there seems to be no authentication -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout>
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Hudson/opensearch.xml.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/opensearch.xml.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   OpenSearch description for using search box from browsers
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 ><st:contentType value="application/xml;charset=UTF-8"
 /><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">

--- a/hudson-core/src/main/resources/hudson/model/Hudson/projectRelationship-help.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/projectRelationship-help.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout>
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Hudson/projectRelationship.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/projectRelationship.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Displays two projects side by side and show their relationship
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Hudson/sidepanel.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/sidepanel.jelly
@@ -22,4 +22,5 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <st:include it="${it.primaryView}" page="sidepanel.jelly" xmlns:st="jelly:stapler" />

--- a/hudson-core/src/main/resources/hudson/model/Hudson/systemInfo.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/systemInfo.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Various system information for diagnostics
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout permission="${app.ADMINISTER}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Hudson/threadDump.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/threadDump.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Produces stack dump of all threads by using JMX.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout permission="${app.ADMINISTER}" title="${%Thread dump}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Hudson/whoAmI.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Hudson/whoAmI.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- show debug information about the current user -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:layout>
     <l:hasPermission permission="${app.READ}">

--- a/hudson-core/src/main/resources/hudson/model/JDK/config.jelly
+++ b/hudson-core/src/main/resources/hudson/model/JDK/config.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Name}" field="name">
     <f:textbox />

--- a/hudson-core/src/main/resources/hudson/model/Job/_api.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Job/_api.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <h2>Fetch/Update config.xml</h2>
   <p>

--- a/hudson-core/src/main/resources/hudson/model/Job/buildTimeTrend.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Job/buildTimeTrend.jelly
@@ -24,6 +24,7 @@ THE SOFTWARE.
 -->
 
 <!-- Displays the chart that show how long builds are taking -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${%title(it.displayName)}">
 		<st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Job/configure-entries.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Job/configure-entries.jelly
@@ -25,4 +25,5 @@ THE SOFTWARE.
 <!--
   derived class should override this JSP to put additional entries to the config page.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" />

--- a/hudson-core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Job/configure.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Config page. derived class specific entries should go to configure-entries.jsp
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName} Config" norefresh="true" permission="${it.EXTENDED_READ}">
     <j:set var="jobUrl" value="${h.getNearestAncestorUrl(request,it)}"/>

--- a/hudson-core/src/main/resources/hudson/model/Job/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Job/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
   <l:layout title="${it.displayName}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Job/jobpropertysummaries.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Job/jobpropertysummaries.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- display permalinks of the page -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
 	<!-- give properties a chance to contribute summary item -->
 	<j:forEach var="p" items="${it.properties.values()}">

--- a/hudson-core/src/main/resources/hudson/model/Job/main.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Job/main.jelly
@@ -23,4 +23,5 @@ THE SOFTWARE.
 -->
 
 <!-- place holder for the derived types to add more contents -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" />

--- a/hudson-core/src/main/resources/hudson/model/Job/newInstanceDetail.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Job/newInstanceDetail.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <!--
     For historical reasons, jobs used "newJobDetail.jelly".

--- a/hudson-core/src/main/resources/hudson/model/Job/permalinks.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Job/permalinks.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- display permalinks of the page -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
   <h2>${%Permalinks}</h2>
   <ul>

--- a/hudson-core/src/main/resources/hudson/model/Job/rename.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Job/rename.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- Rename project -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Job/rssHeader.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Job/rssHeader.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
   <link rel="alternate" title="Hudson:${it.name} (all builds)" href="rssAll" type="application/rss+xml" />
   <link rel="alternate" title="Hudson:${it.name} (all builds) (RSS 2.0)" href="rssAll?flavor=rss20" type="application/rss+xml" />

--- a/hudson-core/src/main/resources/hudson/model/Label/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Label/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Label/load-statistics.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Label/load-statistics.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName} Load Statistics">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Label/sidepanel.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Label/sidepanel.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Side panel for a label.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:header title="Label ${it.displayName}" />
   <l:side-panel>

--- a/hudson-core/src/main/resources/hudson/model/ListView/newViewDetail.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ListView/newViewDetail.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <div>
   ${%blurb} 
 </div>

--- a/hudson-core/src/main/resources/hudson/model/LoadStatistics/main.jelly
+++ b/hudson-core/src/main/resources/hudson/model/LoadStatistics/main.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- renders an HTML fragment that shows trend graph -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <h1>
     <img src="${imagesURL}/48x48/monitor.gif" alt=""/>

--- a/hudson-core/src/main/resources/hudson/model/MyView/newViewDetail.jelly
+++ b/hudson-core/src/main/resources/hudson/model/MyView/newViewDetail.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <div>
   ${%blurb} 
 </div>

--- a/hudson-core/src/main/resources/hudson/model/MyView/noJob.jelly
+++ b/hudson-core/src/main/resources/hudson/model/MyView/noJob.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <div>
   ${%blurb}
 </div>

--- a/hudson-core/src/main/resources/hudson/model/MyViewsProperty/config.jelly
+++ b/hudson-core/src/main/resources/hudson/model/MyViewsProperty/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Default View}"
     description="${%description}">

--- a/hudson-core/src/main/resources/hudson/model/MyViewsProperty/newView.jelly
+++ b/hudson-core/src/main/resources/hudson/model/MyViewsProperty/newView.jelly
@@ -27,6 +27,7 @@ THE SOFTWARE.
   
   TODO remove duplication with Hudson/newView.jelly
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true" permission="${app.primaryView.CREATE}">
     <st:include page="sidepanel.jelly" it="${it.user}"/>

--- a/hudson-core/src/main/resources/hudson/model/NoFingerprintMatch/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/NoFingerprintMatch/index.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- used when fingerprint had no match -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <l:header title="${%No matching record found}" />
@@ -38,7 +39,7 @@ THE SOFTWARE.
       </h1>
 
       <p>
-        ${%description(h.escape(it.displayName))}
+        ${%description(it.displayName)}
       </p>
       <ol>
         <li>

--- a/hudson-core/src/main/resources/hudson/model/ParameterDefinition/config.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ParameterDefinition/config.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   This Jelly view shows UI for configuring parameter definitions as a part of the job configuration.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">

--- a/hudson-core/src/main/resources/hudson/model/ParametersDefinitionProperty/config.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ParametersDefinitionProperty/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">

--- a/hudson-core/src/main/resources/hudson/model/ParametersDefinitionProperty/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ParametersDefinitionProperty/index.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   This view is rendered as /hudson/job/XYZ/build
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
@@ -39,7 +40,7 @@ THE SOFTWARE.
       <h1>${it.owner.pronoun} ${it.owner.displayName}</h1>
       <j:if test="${!empty(it.owner.description)}">
           <div id="description">
-              ${app.markupFormatter.translate(it.owner.description)}
+              <j:out value="${app.markupFormatter.translate(it.owner.description)}"/>
           </div>
       </j:if>
       <p>${%description}</p>

--- a/hudson-core/src/main/resources/hudson/model/PasswordParameterDefinition/config.jelly
+++ b/hudson-core/src/main/resources/hudson/model/PasswordParameterDefinition/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">

--- a/hudson-core/src/main/resources/hudson/model/PasswordParameterDefinition/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/PasswordParameterDefinition/index.jelly
@@ -22,10 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<f:entry title="${it.name}" description="${it.description}">
+	<f:entry title="${it.name!=null ? app.markupFormatter.translate(it.name) : ''}"
+	   description="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}">
 		<div name="parameter" description="${it.description}">
 			<input type="hidden" name="name" value="${it.name}" />
 			<f:password name="value" value="${it.defaultValue}" />

--- a/hudson-core/src/main/resources/hudson/model/PasswordParameterValue/value.jelly
+++ b/hudson-core/src/main/resources/hudson/model/PasswordParameterValue/value.jelly
@@ -22,10 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<f:entry title="${it.name}" description="${it.description}">
+	<f:entry title="${it.name!=null ? app.markupFormatter.translate(it.name) : ''}"
+	   description="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}">
 		<f:password name="value" value="********" readonly="true" />
 	</f:entry>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/PermalinkProjectAction/Permalink/link.jelly
+++ b/hudson-core/src/main/resources/hudson/model/PermalinkProjectAction/Permalink/link.jelly
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
   'job' must be bound to the parent job scope.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project">
   <j:set var="b" value="${it.resolve(job)}"/>
   <j:if test="${b!=null}">

--- a/hudson-core/src/main/resources/hudson/model/Project/configure-entries.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Project/configure-entries.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project">
   <j:set var="jobUrl" value="${h.getNearestAncestorUrl(request,it)}"/>
   <st:include page="configure-common.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/ProxyView/configure-entries.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ProxyView/configure-entries.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="${%View name}"
     description="${%The name of a global view that will be shown.}">

--- a/hudson-core/src/main/resources/hudson/model/ProxyView/main.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ProxyView/main.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <st:include it="${it.proxiedView}" page="main.jelly"/>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/ProxyView/newViewDetail.jelly
+++ b/hudson-core/src/main/resources/hudson/model/ProxyView/newViewDetail.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <div>
   ${%Shows the content of a global view.}
 </div>

--- a/hudson-core/src/main/resources/hudson/model/Run/KeepLogBuildBadge/badge.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Run/KeepLogBuildBadge/badge.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <img width="16" height="16"
   title="${%Keep this build forever}" alt="[saved]"
   src="${imagesURL}/16x16/lock.gif"/>

--- a/hudson-core/src/main/resources/hudson/model/Run/_api.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Run/_api.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <h2>Other Useful URLs</h2>
   <dl>

--- a/hudson-core/src/main/resources/hudson/model/Run/artifacts-index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Run/artifacts-index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:if test="${!h.isArtifactsPermissionEnabled() or h.isArtifactsPermissionEnabled() and h.hasPermission(it.ARTIFACTS)}">
     <l:layout title="${it.fullDisplayName} Artifacts">
@@ -32,7 +33,7 @@ THE SOFTWARE.
         </t:buildCaption>
         <ul>
           <j:forEach var="f" items="${it.artifacts}">
-            <li><a href="artifact/${f.href}">${h.xmlEscape(f.displayPath)}</a></li>
+            <li><a href="artifact/${f.href}">${f.displayPath}</a></li>
           </j:forEach>
         </ul>
       </l:main-panel>

--- a/hudson-core/src/main/resources/hudson/model/Run/configure.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Run/configure.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName} Config" norefresh="true">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Run/console.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Run/console.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Displays the console output
 -->
+<?jelly escape-by-default='true'?>
 <st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.fullDisplayName} Console" norefresh="true">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Run/consoleFull.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Run/consoleFull.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:set var="consoleFull" value="true" />
   <st:include page="console.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/Run/delete.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Run/delete.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Displays the button to delete the build.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:if test="${!it.keepLog and !it.building}">
     <form method="get" action="confirmDelete" style="margin-top:1em">

--- a/hudson-core/src/main/resources/hudson/model/Run/logKeep.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Run/logKeep.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Displays the toggle button to keep/don't-keep the log file.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:if test="${it.parent.logRotator!=null}">
     <form method="get" action="toggleLogKeep" style="margin-top:1em">

--- a/hudson-core/src/main/resources/hudson/model/RunParameterDefinition/config.jelly
+++ b/hudson-core/src/main/resources/hudson/model/RunParameterDefinition/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">

--- a/hudson-core/src/main/resources/hudson/model/RunParameterDefinition/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/RunParameterDefinition/index.jelly
@@ -22,10 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<f:entry title="${it.name}" description="${it.description}">
+	<f:entry title="${it.name!=null ? app.markupFormatter.translate(it.name) : ''}"
+	   description="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}">
 		<div name="parameter" description="${it.description}">
 			<input type="hidden" name="name" value="${it.name}" />
             <select name="runId">

--- a/hudson-core/src/main/resources/hudson/model/RunParameterValue/value.jelly
+++ b/hudson-core/src/main/resources/hudson/model/RunParameterValue/value.jelly
@@ -22,10 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<f:entry title="${it.name}" description="${it.description}">
+	<f:entry title="${it.name!=null ? app.markupFormatter.translate(it.name) : ''}"
+	   description="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}">
 		<a href="${rootURL}/${it.run.url}">${it.run}</a>
 	</f:entry>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/Slave/help-launcher.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Slave/help-launcher.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:ajax>
     <div>

--- a/hudson-core/src/main/resources/hudson/model/StringParameterDefinition/config.jelly
+++ b/hudson-core/src/main/resources/hudson/model/StringParameterDefinition/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">

--- a/hudson-core/src/main/resources/hudson/model/StringParameterDefinition/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/StringParameterDefinition/index.jelly
@@ -22,10 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<f:entry title="${it.name}" description="${it.description}">
+	<f:entry title="${it.name!=null ? app.markupFormatter.translate(it.name) : ''}"
+	   description="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}">
 		<div name="parameter" description="${it.description}">
 			<input type="hidden" name="name" value="${it.name}" />
 			<f:textbox name="value" value="${it.defaultValue}" />

--- a/hudson-core/src/main/resources/hudson/model/StringParameterValue/value.jelly
+++ b/hudson-core/src/main/resources/hudson/model/StringParameterValue/value.jelly
@@ -22,10 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-	<f:entry title="${it.name}" description="${it.description}">
+	<f:entry title="${it.name!=null ? app.markupFormatter.translate(it.name) : ''}"
+	   description="${it.description!=null ? app.markupFormatter.translate(it.description) : ''}">
 		<f:textbox name="value" value="${it.value}" readonly="true" />
 	</f:entry>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/TaskAction/log.jelly
+++ b/hudson-core/src/main/resources/hudson/model/TaskAction/log.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Include this in the main page to display the log
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:choose>
     <!-- Do progressive console output -->

--- a/hudson-core/src/main/resources/hudson/model/TreeView/ajaxRows.jelly
+++ b/hudson-core/src/main/resources/hudson/model/TreeView/ajaxRows.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Used to render the folder content through an AJAX call.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:ajax>
     <t:setIconSize/>

--- a/hudson-core/src/main/resources/hudson/model/TreeView/main.jelly
+++ b/hudson-core/src/main/resources/hudson/model/TreeView/main.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:choose>
     <j:when test="${empty(items)}">

--- a/hudson-core/src/main/resources/hudson/model/TreeView/newView.jelly
+++ b/hudson-core/src/main/resources/hudson/model/TreeView/newView.jelly
@@ -22,4 +22,5 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <st:include from="${app}" page="newView.jelly" xmlns:st="jelly:stapler" />

--- a/hudson-core/src/main/resources/hudson/model/TreeView/newViewDetail.jelly
+++ b/hudson-core/src/main/resources/hudson/model/TreeView/newViewDetail.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <div>
   <b>Experimental:</b> show hierarchical views 
 </div>

--- a/hudson-core/src/main/resources/hudson/model/TreeView/sidepanel2.jelly
+++ b/hudson-core/src/main/resources/hudson/model/TreeView/sidepanel2.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Side panel for the build view.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:task icon="images/32x32/folder.gif" href="newView" title="${%New View}"  permission="${it.CONFIGURE}" />
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/UpdateCenter/ConnectionCheckJob/row.jelly
+++ b/hudson-core/src/main/resources/hudson/model/UpdateCenter/ConnectionCheckJob/row.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <tr id="row${it.id}">
     <td style="vertical-align: top; padding-right:1em">${%Preparation}</td>
@@ -29,7 +30,7 @@ THE SOFTWARE.
     <td id="prepStatus${size(statuses)}">
       <ul>
         <j:forEach var="s" items="${statuses}">
-          <li>${s}</li>
+          <li><j:out value="${s}"/></li>
         </j:forEach>
       </ul>
     </td>

--- a/hudson-core/src/main/resources/hudson/model/UpdateCenter/CoreUpdateMonitor/message.jelly
+++ b/hudson-core/src/main/resources/hudson/model/UpdateCenter/CoreUpdateMonitor/message.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="warning">
     <j:set var="ucData" value="${it.data}" />

--- a/hudson-core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Failure/status.jelly
+++ b/hudson-core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Failure/status.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div>
     <img src="${imagesURL}/24x24/red.gif" alt=""/> ${%Failure}

--- a/hudson-core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Installing/status.jelly
+++ b/hudson-core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Installing/status.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div>
     <img src="${imagesURL}/24x24/grey_anime.gif" alt=""/> ${%Installing}

--- a/hudson-core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Pending/status.jelly
+++ b/hudson-core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Pending/status.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <img src="${imagesURL}/24x24/grey.gif" alt=""/> ${%Pending}
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Success/status.jelly
+++ b/hudson-core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/Success/status.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <img src="${imagesURL}/24x24/blue.gif" alt=""/> ${%Success}
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/row.jelly
+++ b/hudson-core/src/main/resources/hudson/model/UpdateCenter/DownloadJob/row.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <tr id="row${it.id}">
     <td style="vertical-align: top; padding-right:1em">${it.name}</td>

--- a/hudson-core/src/main/resources/hudson/model/UpdateCenter/PageDecoratorImpl/footer.jelly
+++ b/hudson-core/src/main/resources/hudson/model/UpdateCenter/PageDecoratorImpl/footer.jelly
@@ -29,6 +29,7 @@ THE SOFTWARE.
 
   This file is pulled into the layout.jelly
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:forEach var="site" items="${app.updateCenter.sites}">
     <j:if test="${site.due or forcedUpdateCheck}">

--- a/hudson-core/src/main/resources/hudson/model/UpdateCenter/body.jelly
+++ b/hudson-core/src/main/resources/hudson/model/UpdateCenter/body.jelly
@@ -26,6 +26,7 @@ THE SOFTWARE.
   Requested by the browser separately to partially update the page.
   Also used as a part of index.jelly rendering.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:ajax>
     <table id="log">

--- a/hudson-core/src/main/resources/hudson/model/UpdateCenter/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/UpdateCenter/index.jelly
@@ -26,6 +26,7 @@ THE SOFTWARE.
 <!--
   This page shows the status of the plugin installation
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <l:layout title="${%Update Center}" permission="${app.ADMINISTER}">
   <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/UpdateCenter/sidepanel.jelly
+++ b/hudson-core/src/main/resources/hudson/model/UpdateCenter/sidepanel.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Side panel
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:header />
   <l:side-panel>

--- a/hudson-core/src/main/resources/hudson/model/UsageStatistics/footer.jelly
+++ b/hudson-core/src/main/resources/hudson/model/UsageStatistics/footer.jelly
@@ -29,6 +29,7 @@ THE SOFTWARE.
 
   This file is pulled into the layout.jelly
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:if test="${it.due}">
     <script>

--- a/hudson-core/src/main/resources/hudson/model/User/deleteConfirmationPanel.jelly
+++ b/hudson-core/src/main/resources/hudson/model/User/deleteConfirmationPanel.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <div>
    <form method="post" action="doDelete">
        <h4>${%Are you sure about deleting the user from Hudson?}</h4>

--- a/hudson-core/src/main/resources/hudson/model/View/People/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/View/People/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="People - ${it.parent.viewName}">
     <st:include page="sidepanel.jelly" it="${it.parent}" />

--- a/hudson-core/src/main/resources/hudson/model/View/ajaxBuildQueue.jelly
+++ b/hudson-core/src/main/resources/hudson/model/View/ajaxBuildQueue.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Used to asynchronously update build queue
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:ajax>
     <t:queue items="${it.queueItems}" />

--- a/hudson-core/src/main/resources/hudson/model/View/ajaxExecutors.jelly
+++ b/hudson-core/src/main/resources/hudson/model/View/ajaxExecutors.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Used to asynchronously update executor queue
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:ajax>
     <t:executors computers="${it.computers}"/>

--- a/hudson-core/src/main/resources/hudson/model/View/builds.jelly
+++ b/hudson-core/src/main/resources/hudson/model/View/builds.jelly
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/View/cc.xml.jelly
+++ b/hudson-core/src/main/resources/hudson/model/View/cc.xml.jelly
@@ -26,6 +26,7 @@ THE SOFTWARE.
   Generate status XML compatible with CruiseControl.
   See http://confluence.public.thoughtworks.org/display/CI/Multiple+Project+Summary+Reporting+Standard
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <st:contentType value="text/xml;charset=UTF-8" />
   <j:new var="h" className="hudson.Functions" />

--- a/hudson-core/src/main/resources/hudson/model/View/configure.jelly
+++ b/hudson-core/src/main/resources/hudson/model/View/configure.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Edit View Page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout norefresh="true">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/View/delete.jelly
+++ b/hudson-core/src/main/resources/hudson/model/View/delete.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- Delete view -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 	<l:layout>
 		<st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/model/View/deleteConfirmationPanel.jelly
+++ b/hudson-core/src/main/resources/hudson/model/View/deleteConfirmationPanel.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <div>
     <form method="post" action="doDelete">
         <h4>${%Are you sure about deleting the view?}</h4>

--- a/hudson-core/src/main/resources/hudson/model/View/index.jelly
+++ b/hudson-core/src/main/resources/hudson/model/View/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <j:if test="${request.servletPath=='/' || request.servletPath==''}">
         <st:header name="X-Hudson" value="${servletContext.getAttribute('version')}" />

--- a/hudson-core/src/main/resources/hudson/model/View/main.jelly
+++ b/hudson-core/src/main/resources/hudson/model/View/main.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <j:choose>
         <j:when test="${empty(items)}">

--- a/hudson-core/src/main/resources/hudson/model/View/newJob.jelly
+++ b/hudson-core/src/main/resources/hudson/model/View/newJob.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   "New Project" page.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <j:getStatic var="permission" className="hudson.model.Item" field="CREATE"/>
   <l:layout norefresh="true" permission="${permission}" title="${%New Job}">

--- a/hudson-core/src/main/resources/hudson/model/View/noJob.jelly
+++ b/hudson-core/src/main/resources/hudson/model/View/noJob.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <style type="text/css">
         #noJobDiv {

--- a/hudson-core/src/main/resources/hudson/model/View/sidepanel.jelly
+++ b/hudson-core/src/main/resources/hudson/model/View/sidepanel.jelly
@@ -26,6 +26,7 @@ THE SOFTWARE.
 <!--
   Side panel for the build view.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:header title="Hudson">
     <link rel="alternate" title="Hudson:${it.viewName} (all builds)" href="${rootURL}/${it.url}rssAll" type="application/rss+xml" />

--- a/hudson-core/src/main/resources/hudson/model/View/sidepanel2.jelly
+++ b/hudson-core/src/main/resources/hudson/model/View/sidepanel2.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Side panel for the build view.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <j:if test="${it.hasPermission(it.CREATE)}">
     <l:task icon="images/32x32/folder.gif" href="${rootURL}/newView" title="${%New View}" permission="${it.CONFIGURE}"/>

--- a/hudson-core/src/main/resources/hudson/model/labels/LabelAtom/configure.jelly
+++ b/hudson-core/src/main/resources/hudson/model/labels/LabelAtom/configure.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true" permission="${app.ADMINISTER}" title="${%title(it.displayName)}">

--- a/hudson-core/src/main/resources/hudson/model/queue/CauseOfBlockage/BecauseLabelIsBusy/summary.jelly
+++ b/hudson-core/src/main/resources/hudson/model/queue/CauseOfBlockage/BecauseLabelIsBusy/summary.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <st:structuredMessageFormat key="description">
     <st:structuredMessageArgument>

--- a/hudson-core/src/main/resources/hudson/model/queue/CauseOfBlockage/BecauseLabelIsOffline/summary.jelly
+++ b/hudson-core/src/main/resources/hudson/model/queue/CauseOfBlockage/BecauseLabelIsOffline/summary.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <st:structuredMessageFormat key="description">
     <st:structuredMessageArgument>

--- a/hudson-core/src/main/resources/hudson/model/queue/CauseOfBlockage/BecauseNodeIsBusy/summary.jelly
+++ b/hudson-core/src/main/resources/hudson/model/queue/CauseOfBlockage/BecauseNodeIsBusy/summary.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <st:structuredMessageFormat key="description">
     <st:structuredMessageArgument>

--- a/hudson-core/src/main/resources/hudson/model/queue/CauseOfBlockage/BecauseNodeIsOffline/summary.jelly
+++ b/hudson-core/src/main/resources/hudson/model/queue/CauseOfBlockage/BecauseNodeIsOffline/summary.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <st:structuredMessageFormat key="description">
     <st:structuredMessageArgument>

--- a/hudson-core/src/main/resources/hudson/model/queue/CauseOfBlockage/summary.jelly
+++ b/hudson-core/src/main/resources/hudson/model/queue/CauseOfBlockage/summary.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
   <!-- defaults to short description -->
   ${it.shortDescription}

--- a/hudson-core/src/main/resources/hudson/node_monitors/AbstractDiskSpaceMonitor/config.jelly
+++ b/hudson-core/src/main/resources/hudson/node_monitors/AbstractDiskSpaceMonitor/config.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="${%Free Space Threshold}" field="freeSpaceThreshold">
     <f:textbox default="1GB"/>

--- a/hudson-core/src/main/resources/hudson/node_monitors/ArchitectureMonitor/column.jelly
+++ b/hudson-core/src/main/resources/hudson/node_monitors/ArchitectureMonitor/column.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <td align="middle">${data}</td>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/node_monitors/ClockMonitor/column.jelly
+++ b/hudson-core/src/main/resources/hudson/node_monitors/ClockMonitor/column.jelly
@@ -22,13 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <j:choose>
     <j:when test="${data==null}">
       <td align="right" data="-1">N/A</td>
     </j:when>
     <j:otherwise>
-      <td align="right" data="${data.abs()}">${data.toHtml()}</td>
+      <td align="right" data="${data.abs()}"><j:out value="${data.toHtml()}"/></td>
     </j:otherwise>
   </j:choose>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/node_monitors/DiskSpaceMonitor/column.jelly
+++ b/hudson-core/src/main/resources/hudson/node_monitors/DiskSpaceMonitor/column.jelly
@@ -22,13 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <j:choose>
     <j:when test="${data==null}">
       <td align="right" data="-1">N/A</td>
     </j:when>
     <j:otherwise>
-      <td align="right" data="${data}">${data.toHtml()}</td>
+      <td align="right" data="${data}"><j:out value="${data.toHtml()}"/></td>
     </j:otherwise>
   </j:choose>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/node_monitors/DiskSpaceMonitorDescriptor/DiskSpace/cause.jelly
+++ b/hudson-core/src/main/resources/hudson/node_monitors/DiskSpaceMonitorDescriptor/DiskSpace/cause.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <p class="error">${%blurb(it.gbLeft)}</p>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/message.jelly
+++ b/hudson-core/src/main/resources/hudson/node_monitors/MonitorMarkedNodeOffline/message.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="warning">
     <form method="post" action="${rootURL}/${it.url}/disable">

--- a/hudson-core/src/main/resources/hudson/node_monitors/ResponseTimeMonitor/Data/cause.jelly
+++ b/hudson-core/src/main/resources/hudson/node_monitors/ResponseTimeMonitor/Data/cause.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <p class="error">${%Ping response time is too long or timed out.}</p>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/node_monitors/ResponseTimeMonitor/column.jelly
+++ b/hudson-core/src/main/resources/hudson/node_monitors/ResponseTimeMonitor/column.jelly
@@ -22,13 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <j:choose>
     <j:when test="${data==null}">
       <td align="right" data="-2">N/A</td>
     </j:when>
     <j:otherwise>
-      <td align="right" data="${data.average()}">${data}</td>
+      <td align="right" data="${data.average()}"><j:out value="${data}"/></td>
     </j:otherwise>
   </j:choose>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/node_monitors/SwapSpaceMonitor/column.jelly
+++ b/hudson-core/src/main/resources/hudson/node_monitors/SwapSpaceMonitor/column.jelly
@@ -22,13 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <j:choose>
     <j:when test="${data==null}">
       <td align="right" data="-1">N/A</td>
     </j:when>
     <j:otherwise>
-      <td align="right" data="${from.toMB(data)}">${from.toHtml(data)}</td>
+      <td align="right" data="${from.toMB(data)}"><j:out value="${from.toHtml(data)}"/></td>
     </j:otherwise>
   </j:choose>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/node_monitors/TemporarySpaceMonitor/column.jelly
+++ b/hudson-core/src/main/resources/hudson/node_monitors/TemporarySpaceMonitor/column.jelly
@@ -22,13 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <j:choose>
     <j:when test="${data==null}">
       <td align="right" data="-1">N/A</td>
     </j:when>
     <j:otherwise>
-      <td align="right" data="${data}">${data.toHtml()}</td>
+      <td align="right" data="${data}"><j:out value="${data.toHtml()}"/></td>
     </j:otherwise>
   </j:choose>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/os/solaris/ZFSInstaller/MigrationCompleteNotice/message.jelly
+++ b/hudson-core/src/main/resources/hudson/os/solaris/ZFSInstaller/MigrationCompleteNotice/message.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="info">
     <form method="post" action="${rootURL}/${it.url}/disable">

--- a/hudson-core/src/main/resources/hudson/os/solaris/ZFSInstaller/MigrationFailedNotice/index.jelly
+++ b/hudson-core/src/main/resources/hudson/os/solaris/ZFSInstaller/MigrationFailedNotice/index.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${%ZFS Migration Problem}">
     <l:main-panel>

--- a/hudson-core/src/main/resources/hudson/os/solaris/ZFSInstaller/MigrationFailedNotice/message.jelly
+++ b/hudson-core/src/main/resources/hudson/os/solaris/ZFSInstaller/MigrationFailedNotice/message.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="error">
     ${%ZFS migration failed.}

--- a/hudson-core/src/main/resources/hudson/os/solaris/ZFSInstaller/askRootPassword.jelly
+++ b/hudson-core/src/main/resources/hudson/os/solaris/ZFSInstaller/askRootPassword.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout title="${%Permission Denied}">
     <l:header />

--- a/hudson-core/src/main/resources/hudson/os/solaris/ZFSInstaller/confirm.jelly
+++ b/hudson-core/src/main/resources/hudson/os/solaris/ZFSInstaller/confirm.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout title="${%ZFS file system creation}">
     <l:header />

--- a/hudson-core/src/main/resources/hudson/os/solaris/ZFSInstaller/message.jelly
+++ b/hudson-core/src/main/resources/hudson/os/solaris/ZFSInstaller/message.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="warning">
     <form method="post" action="${rootURL}/${it.url}/act">

--- a/hudson-core/src/main/resources/hudson/os/windows/ManagedWindowsServiceConnector/config.jelly
+++ b/hudson-core/src/main/resources/hudson/os/windows/ManagedWindowsServiceConnector/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:include page="config.jelly" class="${descriptor.CONFIG_DELEGATE_TO}"/>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/config.jelly
+++ b/hudson-core/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Administrator user name}" field="userName">
     <f:textbox />

--- a/hudson-core/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/help.jelly
+++ b/hudson-core/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/help.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   ${%blurb}
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/rss20.jelly
+++ b/hudson-core/src/main/resources/hudson/rss20.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"><!-- No whitespace before xml header: -->&lt;?xml version="1.0" encoding="UTF-8"?&gt;
   <st:contentType value="text/xml;charset=UTF-8" />
   <j:new var="h" className="hudson.Functions" /><!-- instead of JSP functions -->
@@ -35,14 +36,14 @@ THE SOFTWARE.
 
       <j:forEach var="e" items="${entries}" >
         <item>
-          <title>${h.xmlEscape(adapter.getEntryTitle(e))}</title>
+          <title>${adapter.getEntryTitle(e)}</title>
           <link>${rootURL}${h.encode(adapter.getEntryUrl(e))}</link>
           <guid isPermaLink="false">${adapter.getEntryID(e)}</guid>
           <pubDate>${h.rfc822Date(adapter.getEntryTimestamp(e))}</pubDate>
           <author><st:out value="${adapter.getEntryAuthor(e)}"/></author>
           <j:set var="desc" value="${adapter.getEntryDescription(e)}"/>
           <j:if test="${desc!=null}">
-            <description>${h.xmlEscape(desc)}</description>
+            <description>${desc}</description>
           </j:if>
         </item>
       </j:forEach>

--- a/hudson-core/src/main/resources/hudson/scm/AbstractScmTagAction/badge.jelly
+++ b/hudson-core/src/main/resources/hudson/scm/AbstractScmTagAction/badge.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:if test="${it.isTagged()}" xmlns:j="jelly:core">
   <a href="${rootURL}/${it.build.url}tagBuild/">
     <img width="16" height="16"

--- a/hudson-core/src/main/resources/hudson/scm/AbstractScmTagAction/inProgress.jelly
+++ b/hudson-core/src/main/resources/hudson/scm/AbstractScmTagAction/inProgress.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true">
     <st:include it="${it.build}" page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/scm/EmptyChangeLogSet/digest.jelly
+++ b/hudson-core/src/main/resources/hudson/scm/EmptyChangeLogSet/digest.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   ${%No changes.}
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/scm/EmptyChangeLogSet/index.jelly
+++ b/hudson-core/src/main/resources/hudson/scm/EmptyChangeLogSet/index.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Displays the CVS change log.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <h2>
     <!-- just show "no changes" -->

--- a/hudson-core/src/main/resources/hudson/scm/NullSCM/config.jelly
+++ b/hudson-core/src/main/resources/hudson/scm/NullSCM/config.jelly
@@ -23,4 +23,5 @@ THE SOFTWARE.
 -->
 
 <!-- nothing to configure -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"  />

--- a/hudson-core/src/main/resources/hudson/scm/SCM/project-changes.jelly
+++ b/hudson-core/src/main/resources/hudson/scm/SCM/project-changes.jelly
@@ -32,6 +32,7 @@ THE SOFTWARE.
   The 'builds' variable contains the collection of AbstractBuild objects
   for which the change should be displayed.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:choose>
     <j:when test="${empty(builds)}">
@@ -48,7 +49,7 @@ THE SOFTWARE.
           <ol>
             <j:forEach var="c" items="${b.changeSet.iterator()}" varStatus="loop">
               <li value="${c.revision}">
-                ${c.msgAnnotated}
+                <j:out value="${c.msgAnnotated}"/>
 
                 &#8212;
 

--- a/hudson-core/src/main/resources/hudson/search/Search/search-failed.jelly
+++ b/hudson-core/src/main/resources/hudson/search/Search/search-failed.jelly
@@ -25,12 +25,13 @@ THE SOFTWARE.
 <!--
   Used when the search didn't have the exact hit.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:set var="q" value="${request.getParameter('q')}"/>
   <j:new var="h" className="hudson.Functions" /><!-- needed for printing title. -->
-  <l:layout title="Search for '${h.escape(q)}'">
+  <l:layout title="Search for '${q}'">
     <l:main-panel>
-      <h1>Search for '${h.escape(q)}'</h1>
+      <h1>Search for '${q}'</h1>
       <j:set var="items" value="${it.getSuggestions(request,q)}"/>
       <j:choose>
         <j:when test="${items.size()==0}">

--- a/hudson-core/src/main/resources/hudson/security/AuthorizationMatrixProperty/config.jelly
+++ b/hudson-core/src/main/resources/hudson/security/AuthorizationMatrixProperty/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:optionalBlock name="useProjectSecurity" title="${%Enable project-based security}" checked="${instance!=null}">
     <j:set var="descriptorPath" value="descriptorByName/AuthorizationMatrixProperty" />

--- a/hudson-core/src/main/resources/hudson/security/FederatedLoginService/UnclaimedIdentityException/error.jelly
+++ b/hudson-core/src/main/resources/hudson/security/FederatedLoginService/UnclaimedIdentityException/error.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   This is used to create the first user.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:statusCode value="403" />
   <l:layout title="${%loginError(it.identifier.pronoun)}">

--- a/hudson-core/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
+++ b/hudson-core/src/main/resources/hudson/security/GlobalMatrixAuthorizationStrategy/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:block xmlns:local="local">
     <j:set var="groups" value="${descriptor.allGroups}"/>

--- a/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/Details/config.jelly
+++ b/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/Details/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:if test="${descriptor.enabled}">
     <f:entry title="${%Password}:">

--- a/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryForm.jelly
+++ b/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/_entryForm.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- tag file sed by both signup.jelly and addUser.jelly -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true" title="${%Sign up}">
     <l:header>

--- a/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/addUser.jelly
+++ b/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/addUser.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Page for admin to create a new user
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <local:_entryForm host="${it}" title="${%Create User}" action="createAccountByAdmin" captcha="${false}" xmlns:local="/hudson/security/HudsonPrivateSecurityRealm" />
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/config.jelly
+++ b/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<f:entry title="" help="/help/security/private-realm/allow-signup.html">
         <f:checkbox name="privateRealm.allowsSignup" checked="${h.defaultToTrue(instance.allowsSignup())}"

--- a/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/delete.jelly
+++ b/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/delete.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
 
     <script src="${resURL}/scripts/popup-dialog.js" type="text/javascript"/>

--- a/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/firstUser.jelly
+++ b/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/firstUser.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   This is used to create the first user.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <local:_entryForm host="${it}" title="${%Create First Admin User}" action="createFirstAccount" captcha="${false}" xmlns:local="/hudson/security/HudsonPrivateSecurityRealm" />
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
+++ b/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout permission="${app.ADMINISTER}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/loginLink.jelly
+++ b/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/loginLink.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout">
   <st:include page="/hudson/security/SecurityRealm/loginLink.jelly" />
   <j:if test="${it.allowsSignup()}">

--- a/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/sidepanel.jelly
+++ b/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/sidepanel.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <l:header />
   <l:side-panel>

--- a/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
+++ b/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signup.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   User self sign up page.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <local:_entryForm host="${app}" title="${%Sign up}" action="createAccount" captcha="${it.isEnableCaptcha()}" xmlns:local="/hudson/security/HudsonPrivateSecurityRealm" />
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signupWithFederatedIdentity.jelly
+++ b/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/signupWithFederatedIdentity.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   User self sign up page.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <local:_entryForm host="${app}" title="${%Sign up}" action="createAccountWithFederatedIdentity" captcha="${true}" xmlns:local="/hudson/security/HudsonPrivateSecurityRealm" />
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/success.jelly
+++ b/hudson-core/src/main/resources/hudson/security/HudsonPrivateSecurityRealm/success.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true">
     <l:hasPermission permission="${app.READ}" it="${app}">

--- a/hudson-core/src/main/resources/hudson/security/LDAPSecurityRealm/config.jelly
+++ b/hudson-core/src/main/resources/hudson/security/LDAPSecurityRealm/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<f:entry title="${%Server}" help="/help/security/ldap/server.html">
 	  <f:textbox name="ldap.server" value="${instance.server}"

--- a/hudson-core/src/main/resources/hudson/security/PAMSecurityRealm/config.jelly
+++ b/hudson-core/src/main/resources/hudson/security/PAMSecurityRealm/config.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:advanced>
     <f:entry title="${%Service Name}">

--- a/hudson-core/src/main/resources/hudson/security/SecurityRealm/loginDialog.jelly
+++ b/hudson-core/src/main/resources/hudson/security/SecurityRealm/loginDialog.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <style type="text/css">
         #loginForm input {

--- a/hudson-core/src/main/resources/hudson/security/SecurityRealm/loginLink.jelly
+++ b/hudson-core/src/main/resources/hudson/security/SecurityRealm/loginLink.jelly
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <j:invokeStatic var="fromEncoded" className="java.net.URLEncoder" method="encode">
 

--- a/hudson-core/src/main/resources/hudson/security/csrf/DefaultCrumbIssuer/config.jelly
+++ b/hudson-core/src/main/resources/hudson/security/csrf/DefaultCrumbIssuer/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="" field="excludeClientIPFromCrumb">
         <f:checkbox checked="${instance.isExcludeClientIPFromCrumb()}" title="${%Enable proxy compatibility}" />

--- a/hudson-core/src/main/resources/hudson/slaves/CommandConnector/config.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/CommandConnector/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Launch command}" field="command">
     <f:textbox />

--- a/hudson-core/src/main/resources/hudson/slaves/CommandLauncher/config.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/CommandLauncher/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Launch command}" field="command">
     <f:textbox />

--- a/hudson-core/src/main/resources/hudson/slaves/CommandLauncher/help.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/CommandLauncher/help.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   ${%blurb}
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/slaves/ComputerLauncher/main.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/ComputerLauncher/main.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:if test="${it.launchSupported and it.offline and !it.temporarilyOffline}">
     <j:choose>

--- a/hudson-core/src/main/resources/hudson/slaves/ComputerLauncherFilter/main.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/ComputerLauncherFilter/main.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <st:include it="${it.core}" page="main.jelly" />
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/slaves/DelegatingComputerLauncher/config.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/DelegatingComputerLauncher/config.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 

--- a/hudson-core/src/main/resources/hudson/slaves/DumbSlave/configure-entries.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/DumbSlave/configure-entries.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Description}" help="/help/system-config/master-slave/description.html">

--- a/hudson-core/src/main/resources/hudson/slaves/DumbSlave/newInstanceDetail.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/DumbSlave/newInstanceDetail.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <div>
   ${%detail}
 </div>

--- a/hudson-core/src/main/resources/hudson/slaves/EnvironmentVariablesNodeProperty/config.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/EnvironmentVariablesNodeProperty/config.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%List of key-value pairs}" help="${descriptor.getHelpPage()}">

--- a/hudson-core/src/main/resources/hudson/slaves/JNLPLauncher/config.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/JNLPLauncher/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:advanced>
     <f:entry title="${%Tunnel connection through}" help="/help/system-config/master-slave/jnlp-tunnel.html">

--- a/hudson-core/src/main/resources/hudson/slaves/JNLPLauncher/help.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/JNLPLauncher/help.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   ${%blurb}
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/JNLPLauncher/main.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:choose>
     <j:when test="${app.slaveAgentPort==-1}">

--- a/hudson-core/src/main/resources/hudson/slaves/OfflineCause/ChannelTermination/cause.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/OfflineCause/ChannelTermination/cause.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <p class="error">${%Connection was broken}</p>
   <pre>${h.printThrowable(it.cause)}</pre>

--- a/hudson-core/src/main/resources/hudson/slaves/OfflineCause/LaunchFailed/cause.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/OfflineCause/LaunchFailed/cause.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <p class="error">${it} <a href="log">${%See log for more details}</a></p>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/slaves/OfflineCause/cause.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/OfflineCause/cause.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <p class="warning">${it}</p>
+  <p class="warning"><j:out value="${it}" /></p>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/slaves/RetentionStrategy/Demand/config.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/RetentionStrategy/Demand/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="${%In demand delay}" help="/help/system-config/master-slave/demand/inDemandDelay.html">

--- a/hudson-core/src/main/resources/hudson/slaves/RetentionStrategy/Scheduled/config.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/RetentionStrategy/Scheduled/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="${%Startup Schedule}" help="/descriptor/hudson.triggers.TimerTrigger/help/spec">

--- a/hudson-core/src/main/resources/hudson/slaves/RetentionStrategy/config.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/RetentionStrategy/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/slaves/SimpleScheduledRetentionStrategy/config.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/SimpleScheduledRetentionStrategy/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="${%Startup Schedule}"  help="/descriptor/hudson.triggers.TimerTrigger/help/spec">

--- a/hudson-core/src/main/resources/hudson/slaves/SlaveComputer/disconnect.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/SlaveComputer/disconnect.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- Disconnect confirmation -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName} ${%disconnect}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/slaves/SlaveComputer/log.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/SlaveComputer/log.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.displayName} log" secured="true">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/slaves/SlaveComputer/sidepanel2.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/SlaveComputer/sidepanel2.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:isAdmin>
     <l:task icon="images/24x24/clipboard.gif" href="log" title="${%Log}" />

--- a/hudson-core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/SlaveComputer/slave-agent.jnlp.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
   <st:contentType value="application/x-java-jnlp-file" />
   <j:new var="h" className="hudson.Functions" />

--- a/hudson-core/src/main/resources/hudson/slaves/SlaveComputer/systemInfo.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/SlaveComputer/systemInfo.jelly
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
   TODO: merge this with Hudson/systemInfo.jelly
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout title="${it.displayName} ${%System Information}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/slaves/SlaveComputer/threadDump.jelly
+++ b/hudson-core/src/main/resources/hudson/slaves/SlaveComputer/threadDump.jelly
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
   TODO: merge this with Hudson/threadDump.jelly
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout title="${%title(it.displayName)}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/tasks/Ant/AntInstallation/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/Ant/AntInstallation/config.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Name}" field="name">
     <f:textbox />

--- a/hudson-core/src/main/resources/hudson/tasks/Ant/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/Ant/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:if test="${!empty(descriptor.installations)}">
     <f:entry title="${%Ant Version}">

--- a/hudson-core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/ArtifactArchiver/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Files to archive}" field="artifacts">

--- a/hudson-core/src/main/resources/hudson/tasks/BatchFile/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/BatchFile/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Command}"
            description="${%description(rootURL)}">

--- a/hudson-core/src/main/resources/hudson/tasks/BuildTrigger/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/BuildTrigger/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<f:entry title="${%Projects to build}">
 	  <f:textbox name="buildTrigger.childProjects" value="${instance.childProjectsValue}"

--- a/hudson-core/src/main/resources/hudson/tasks/Fingerprinter/FingerprintAction/index.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/Fingerprinter/FingerprintAction/index.jelly
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
   This belongs to a build view.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout>
     <st:include it="${it.build}" page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/tasks/JavadocArchiver/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/JavadocArchiver/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Javadoc directory}"
     description="${%description}">

--- a/hudson-core/src/main/resources/hudson/tasks/LogRotator/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/LogRotator/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Days to keep builds}"
     description="${%if not empty, build records are only kept up to this number of days}"

--- a/hudson-core/src/main/resources/hudson/tasks/Mailer/UserProperty/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/Mailer/UserProperty/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%E-mail address}"
     description="${%description}">

--- a/hudson-core/src/main/resources/hudson/tasks/Mailer/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/Mailer/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Recipients}" description="${%description}">
     <f:textbox name="mailer_recipients" value="${instance.recipients}"/>

--- a/hudson-core/src/main/resources/hudson/tasks/Mailer/global.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/Mailer/global.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="${%E-mail Notification}">
     <f:entry title="${%SMTP server}" field="smtpServer">

--- a/hudson-core/src/main/resources/hudson/tasks/Maven/MavenInstallation/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/Maven/MavenInstallation/config.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Name}" field="name">
     <f:textbox />

--- a/hudson-core/src/main/resources/hudson/tasks/Maven/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/Maven/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:if test="${!empty(descriptor.installations)}">
     <f:entry title="${%Maven Version}">

--- a/hudson-core/src/main/resources/hudson/tasks/Shell/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/Shell/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Command}" description="${%description(rootURL)}">
     <f:textarea name="command" value="${instance.command}" class="fixed-width" />

--- a/hudson-core/src/main/resources/hudson/tasks/Shell/global.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/Shell/global.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="${%Shell}">
     <f:entry title="${%Shell executable}" help="/help/shell/shellexe.html">

--- a/hudson-core/src/main/resources/hudson/tasks/junit/CaseResult/index.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/junit/CaseResult/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout title="${it.owner} test - ${it.displayName}">
@@ -69,22 +70,22 @@ THE SOFTWARE.
 
       <j:if test="${!empty(it.errorDetails)}">
     <h3>${%Error Message}</h3>
-      <pre>${it.annotate(it.errorDetails)}</pre>
+      <pre><j:out value="${it.annotate(it.errorDetails)}"/></pre>
       </j:if>
 
       <j:if test="${!empty(it.errorStackTrace)}">
     <h3>${%Stacktrace}</h3>
-      <pre>${it.annotate(it.errorStackTrace)}</pre>
+      <pre><j:out value="${it.annotate(it.errorStackTrace)}"/></pre>
       </j:if>
 
       <j:if test="${!empty(it.stdout)}">
         <h3>${%Standard Output}</h3>
-        <pre>${it.annotate(it.stdout)}</pre>
+        <pre><j:out value="${it.annotate(it.stdout)}"/></pre>
       </j:if>
 
       <j:if test="${!empty(it.stderr)}">
         <h3>${%Standard Error}</h3>
-        <pre>${it.annotate(it.stderr)}</pre>
+        <pre><j:out value="${it.annotate(it.stderr)}"/></pre>
       </j:if>
     </l:main-panel>
   </l:layout>

--- a/hudson-core/src/main/resources/hudson/tasks/junit/CaseResult/list.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/junit/CaseResult/list.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Trend of test execution over time.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <table class="pane sortable" id="testresult">
@@ -46,7 +47,7 @@ THE SOFTWARE.
               <st:include it="${badge}" page="badge.jelly" optional="true"/>
             </j:forEach>
             </td>
-            <td class="pane" style="text-align:left">${test.description}</td>
+            <td class="pane" style="text-align:left"><j:out value="${test.description!=null ? app.markupFormatter.translate(test.description) : ''}"/></td>
             <td class="pane" style="text-align:left" data="${test.duration}">${test.durationString}</td>
             <td class="pane">
               <j:set var="pst" value="${test.status}" />

--- a/hudson-core/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/junit/CaseResult/summary.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!--  this is loaded on demand in the failed test results summary -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:contentType value="text/plain"/>
@@ -34,7 +35,7 @@ THE SOFTWARE.
 		<j:otherwise>
 			<j:if test="${it.errorStackTrace!=null}">
 				<h3>${%Stack Trace}</h3>
-				<pre><st:out value="${it.errorStackTrace}"/></pre>
+                                <pre><j:out value="${it.annotate(it.errorStackTrace)}"/></pre>
 			</j:if>
 		</j:otherwise>
   </j:choose>

--- a/hudson-core/src/main/resources/hudson/tasks/junit/ClassResult/body.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/junit/ClassResult/body.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:if test="${it.totalCount!=0}">
     <h2>${%All Tests}</h2>

--- a/hudson-core/src/main/resources/hudson/tasks/junit/ClassResult/list.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/junit/ClassResult/list.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <table class="pane sortable" id="testresult">
@@ -45,7 +46,7 @@ THE SOFTWARE.
 		          <st:include it="${badge}" page="badge.jelly" optional="true"/>
 		        </j:forEach>
             </td>
-            <td class="pane" style="text-align:right">${p.description}</td>
+            <td class="pane" style="text-align:right"><j:out value="${p.description!=null ? app.markupFormatter.translate(p.description) : ''}"/></td>
             <td class="pane" style="text-align:right" data="${p.duration}">${p.durationString}</td>
             <td class="pane" style="text-align:right">${p.failCount}</td>
             <td class="pane" style="text-align:right">${p.skipCount}</td>

--- a/hudson-core/src/main/resources/hudson/tasks/junit/History/index.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/junit/History/index.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- Displays the chart that show how long builds are taking -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${%title(it.testObject.displayName)}">
 		<j:set var="start" value="${request.getParameter('start')?:0}"/>

--- a/hudson-core/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/junit/JUnitResultArchiver/config.jelly
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<f:entry title="${%Test report XMLs}" field="testResults"

--- a/hudson-core/src/main/resources/hudson/tasks/test/AbstractTestResultAction/summary.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/test/AbstractTestResultAction/summary.jelly
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 
   <script type="text/javascript">

--- a/hudson-core/src/main/resources/hudson/tasks/test/AggregatedTestResultPublisher/TestResultAction/index.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/test/AggregatedTestResultPublisher/TestResultAction/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local" xmlns:test="/lib/test">
   <l:layout title="Test">
     <st:include page="sidepanel.jelly" it="${it.owner}"/>

--- a/hudson-core/src/main/resources/hudson/tasks/test/AggregatedTestResultPublisher/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/test/AggregatedTestResultPublisher/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:nested>
     <table style="width:100%">

--- a/hudson-core/src/main/resources/hudson/tasks/test/MatrixTestResult/index.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/test/MatrixTestResult/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local" xmlns:test="/lib/test">
   <l:layout title="Test">
     <st:include page="sidepanel.jelly" it="${it.owner}"/>

--- a/hudson-core/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/test/MetaTabulatedResult/body.jelly
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
   <script type="text/javascript">

--- a/hudson-core/src/main/resources/hudson/tasks/test/MetaTabulatedResult/list.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/test/MetaTabulatedResult/list.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <table class="pane sortable" id="testresult">
@@ -45,7 +46,7 @@ THE SOFTWARE.
 		          <st:include it="${badge}" page="badge.jelly" optional="true"/>
 		        </j:forEach>
             </td>
-            <td class="pane" style="text-align:right">${p.description}</td>
+            <td class="pane" style="text-align:right"><j:out value="${p.description!=null ? app.markupFormatter.translate(p.description) : ''}"/></td>
             <td class="pane" style="text-align:right" data="${p.duration}">${p.durationString}</td>
             <td class="pane" style="text-align:right">${p.failCount}</td>
             <td class="pane" style="text-align:right">${p.skipCount}</td>

--- a/hudson-core/src/main/resources/hudson/tasks/test/TestObject/sidepanel.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/test/TestObject/sidepanel.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Side panel for the build view.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:header />
   <l:side-panel>

--- a/hudson-core/src/main/resources/hudson/tasks/test/TestResult/index.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/test/TestResult/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:test="/lib/test">
   <l:layout title="${it.owner} ${it.displayName}">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/test/TestResultProjectAction/floatingBox.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
   <j:set var="tr" value="${action.lastTestResultAction}" />
   <j:if test="${tr.previousResult!=null}">

--- a/hudson-core/src/main/resources/hudson/tasks/test/TestResultProjectAction/index.jelly
+++ b/hudson-core/src/main/resources/hudson/tasks/test/TestResultProjectAction/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
   <l:layout title="Test">
     <st:include page="sidepanel.jelly" it="${it.project}" />

--- a/hudson-core/src/main/resources/hudson/tools/CommandInstaller/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tools/CommandInstaller/config.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:t="/hudson/tools">
     <t:label />
     <f:entry title="${%Command}" field="command">

--- a/hudson-core/src/main/resources/hudson/tools/DownloadFromUrlInstaller/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tools/DownloadFromUrlInstaller/config.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="${%Version}" field="id">
     <j:choose>

--- a/hudson-core/src/main/resources/hudson/tools/InstallSourceProperty/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tools/InstallSourceProperty/config.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:block>
         <j:invokeStatic var="descriptors" className="hudson.tools.ToolInstallerDescriptor" method="for_">

--- a/hudson-core/src/main/resources/hudson/tools/JDKInstaller/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tools/JDKInstaller/config.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <!-- XXX t:label? -->
   <f:entry title="${%Version}" field="id">

--- a/hudson-core/src/main/resources/hudson/tools/ToolInstallation/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tools/ToolInstallation/config.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Per ToolInstallation configuration page added to the system configuration.

--- a/hudson-core/src/main/resources/hudson/tools/ToolInstallation/global.jelly
+++ b/hudson-core/src/main/resources/hudson/tools/ToolInstallation/global.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="${descriptor.displayName}">
     <f:entry title="${%title(descriptor.displayName)}" description="${%description(descriptor.displayName)}">

--- a/hudson-core/src/main/resources/hudson/tools/ToolLocationNodeProperty/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tools/ToolLocationNodeProperty/config.jelly
@@ -21,6 +21,7 @@
   ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   ~ THE SOFTWARE.
   -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<f:entry title="${%List of tool locations}" help="/help/tools/tool-location-node-property.html">

--- a/hudson-core/src/main/resources/hudson/tools/ZipExtractionInstaller/config.jelly
+++ b/hudson-core/src/main/resources/hudson/tools/ZipExtractionInstaller/config.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:t="/hudson/tools">
     <t:label />
     <f:entry title="${%Download URL for binary archive}" field="url">

--- a/hudson-core/src/main/resources/hudson/tools/label.jelly
+++ b/hudson-core/src/main/resources/hudson/tools/label.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
     <st:documentation>
         Puts the input field for allowing an user to limit this installer to a certain label.

--- a/hudson-core/src/main/resources/hudson/triggers/SCMTrigger/AdministrativeMonitorImpl/message.jelly
+++ b/hudson-core/src/main/resources/hudson/triggers/SCMTrigger/AdministrativeMonitorImpl/message.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <div class='warning'>
   ${%blurb}
 </div>

--- a/hudson-core/src/main/resources/hudson/triggers/SCMTrigger/BuildAction/index.jelly
+++ b/hudson-core/src/main/resources/hudson/triggers/SCMTrigger/BuildAction/index.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Displays the polling log output
 -->
+<?jelly escape-by-default='true'?>
 <st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.build.parent.displayName} #${it.build.number} ${%Polling Log}" norefresh="true">
     <st:include it="${it.build}" page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/triggers/SCMTrigger/DescriptorImpl/index.jelly
+++ b/hudson-core/src/main/resources/hudson/triggers/SCMTrigger/DescriptorImpl/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout title="${%Current SCM Polling Activities}">
     <st:include it="${app}" page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/triggers/SCMTrigger/SCMAction/index.jelly
+++ b/hudson-core/src/main/resources/hudson/triggers/SCMTrigger/SCMAction/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout>
     <st:include it="${it.owner}" page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/hudson/triggers/SCMTrigger/SCMTriggerCause/description.jelly
+++ b/hudson-core/src/main/resources/hudson/triggers/SCMTrigger/SCMTriggerCause/description.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <span><a href="pollingLog">${it.shortDescription}</a></span>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/triggers/SCMTrigger/config.jelly
+++ b/hudson-core/src/main/resources/hudson/triggers/SCMTrigger/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="instanceProperty" value="${cu.getTriggerProjectProperty(it, descriptor.jsonSafeClassName)}"/>
   <j:set var="instance" value="${instanceProperty.getValue()}"/>

--- a/hudson-core/src/main/resources/hudson/triggers/SCMTrigger/global.jelly
+++ b/hudson-core/src/main/resources/hudson/triggers/SCMTrigger/global.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:if test="${app.items.size()>10}">
     <!--

--- a/hudson-core/src/main/resources/hudson/triggers/TimerTrigger/config.jelly
+++ b/hudson-core/src/main/resources/hudson/triggers/TimerTrigger/config.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="instanceProperty" value="${cu.getTriggerProjectProperty(it, descriptor.jsonSafeClassName)}"/>
   <j:set var="instance" value="${instanceProperty.getValue()}"/>

--- a/hudson-core/src/main/resources/hudson/util/AWTProblem/index.jelly
+++ b/hudson-core/src/main/resources/hudson/util/AWTProblem/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <l:header title="Hudson" />

--- a/hudson-core/src/main/resources/hudson/util/AdministrativeError/index.jelly
+++ b/hudson-core/src/main/resources/hudson/util/AdministrativeError/index.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="${it.title}">
     <l:main-panel>

--- a/hudson-core/src/main/resources/hudson/util/AdministrativeError/message.jelly
+++ b/hudson-core/src/main/resources/hudson/util/AdministrativeError/message.jelly
@@ -22,9 +22,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="error">
-    ${it.message}
+    <j:out value="${it.message}"/>
     <a href="${it.url}/">${%See the log for more details}</a>.
   </div>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/util/DoubleLaunchChecker/index.jelly
+++ b/hudson-core/src/main/resources/hudson/util/DoubleLaunchChecker/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <l:header title="Hudson">

--- a/hudson-core/src/main/resources/hudson/util/HudsonFailedToLoad/index.jelly
+++ b/hudson-core/src/main/resources/hudson/util/HudsonFailedToLoad/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <l:header title="Hudson" />

--- a/hudson-core/src/main/resources/hudson/util/HudsonIsLoading/index.jelly
+++ b/hudson-core/src/main/resources/hudson/util/HudsonIsLoading/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <st:statusCode value="503" /><!-- SERVICE NOT AVAILABLE -->
   <l:layout title="Hudson">

--- a/hudson-core/src/main/resources/hudson/util/HudsonIsRestarting/index.jelly
+++ b/hudson-core/src/main/resources/hudson/util/HudsonIsRestarting/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <st:statusCode value="503" /><!-- SERVICE NOT AVAILABLE -->
   <l:layout>

--- a/hudson-core/src/main/resources/hudson/util/IncompatibleAntVersionDetected/index.jelly
+++ b/hudson-core/src/main/resources/hudson/util/IncompatibleAntVersionDetected/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <l:header title="Hudson" />

--- a/hudson-core/src/main/resources/hudson/util/IncompatibleServletVersionDetected/index.jelly
+++ b/hudson-core/src/main/resources/hudson/util/IncompatibleServletVersionDetected/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <l:header title="Hudson" />

--- a/hudson-core/src/main/resources/hudson/util/IncompatibleVMDetected/index.jelly
+++ b/hudson-core/src/main/resources/hudson/util/IncompatibleVMDetected/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <l:header title="Hudson" />

--- a/hudson-core/src/main/resources/hudson/util/InsufficientPermissionDetected/index.jelly
+++ b/hudson-core/src/main/resources/hudson/util/InsufficientPermissionDetected/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <l:header title="Hudson" />

--- a/hudson-core/src/main/resources/hudson/util/JNADoublyLoaded/index.jelly
+++ b/hudson-core/src/main/resources/hudson/util/JNADoublyLoaded/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="Hudson">
     <l:header />

--- a/hudson-core/src/main/resources/hudson/util/NoHomeDir/index.jelly
+++ b/hudson-core/src/main/resources/hudson/util/NoHomeDir/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <l:header title="Hudson" />

--- a/hudson-core/src/main/resources/hudson/util/NoTempDir/index.jelly
+++ b/hudson-core/src/main/resources/hudson/util/NoTempDir/index.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout>
     <l:header title="Hudson" />

--- a/hudson-core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
+++ b/hudson-core/src/main/resources/hudson/views/BuildButtonColumn/column.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
       <td>
           <j:if test="${job.buildable and job.hasPermission(job.BUILD)}">

--- a/hudson-core/src/main/resources/hudson/views/BuildButtonColumn/columnHeader.jelly
+++ b/hudson-core/src/main/resources/hudson/views/BuildButtonColumn/columnHeader.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
     <th width="1">
         <st:nbsp/>

--- a/hudson-core/src/main/resources/hudson/views/ConsoleColumn/column.jelly
+++ b/hudson-core/src/main/resources/hudson/views/ConsoleColumn/column.jelly
@@ -22,6 +22,7 @@
   THE SOFTWARE.
   -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
   <td>
     <j:choose>

--- a/hudson-core/src/main/resources/hudson/views/ConsoleColumn/columnHeader.jelly
+++ b/hudson-core/src/main/resources/hudson/views/ConsoleColumn/columnHeader.jelly
@@ -22,6 +22,7 @@
   THE SOFTWARE.
   -->
 
+<?jelly escape-by-default='true'?>
  <j:jelly xmlns:j="jelly:core">
     <th>${%Console}</th>
  </j:jelly>

--- a/hudson-core/src/main/resources/hudson/views/DefaultMyViewsTabBar/myViewTabs.jelly
+++ b/hudson-core/src/main/resources/hudson/views/DefaultMyViewsTabBar/myViewTabs.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <!-- view tab bar -->
   <l:tabBar>

--- a/hudson-core/src/main/resources/hudson/views/DefaultViewsTabBar/viewTabs.jelly
+++ b/hudson-core/src/main/resources/hudson/views/DefaultViewsTabBar/viewTabs.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <!-- view tab bar -->
   <l:tabBar>

--- a/hudson-core/src/main/resources/hudson/views/JobColumn/column.jelly
+++ b/hudson-core/src/main/resources/hudson/views/JobColumn/column.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <td class="jobDescription"
         style="${indenter.getCss(job)}"

--- a/hudson-core/src/main/resources/hudson/views/JobColumn/columnHeader.jelly
+++ b/hudson-core/src/main/resources/hudson/views/JobColumn/columnHeader.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <th initialSortDir="down">${%Job}</th>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/views/LastDurationColumn/column.jelly
+++ b/hudson-core/src/main/resources/hudson/views/LastDurationColumn/column.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
       <td data="${lsBuild.duration ?: lfBuild.duration ?: '0'}">
           <j:choose>

--- a/hudson-core/src/main/resources/hudson/views/LastDurationColumn/columnHeader.jelly
+++ b/hudson-core/src/main/resources/hudson/views/LastDurationColumn/columnHeader.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <th>${%Last Duration}</th>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/views/LastFailureColumn/column.jelly
+++ b/hudson-core/src/main/resources/hudson/views/LastFailureColumn/column.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <td data="${lfBuild.timestampString2 ?: '-'}">
           <j:choose>

--- a/hudson-core/src/main/resources/hudson/views/LastFailureColumn/columnHeader.jelly
+++ b/hudson-core/src/main/resources/hudson/views/LastFailureColumn/columnHeader.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <th>${%Last Failure}</th>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/views/LastStableColumn/column.jelly
+++ b/hudson-core/src/main/resources/hudson/views/LastStableColumn/column.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <j:set var="lstBuild" value="${job.lastStableBuild}"/>
     <td data="${lstBuild.timestampString2 ?: '-'}">

--- a/hudson-core/src/main/resources/hudson/views/LastStableColumn/columnHeader.jelly
+++ b/hudson-core/src/main/resources/hudson/views/LastStableColumn/columnHeader.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <th>${%Last Stable}</th>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/views/LastSuccessColumn/column.jelly
+++ b/hudson-core/src/main/resources/hudson/views/LastSuccessColumn/column.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <td data="${lsBuild.timestampString2 ?: '-'}">
           <j:choose>

--- a/hudson-core/src/main/resources/hudson/views/LastSuccessColumn/columnHeader.jelly
+++ b/hudson-core/src/main/resources/hudson/views/LastSuccessColumn/columnHeader.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <th>${%Last Success}</th>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/views/ListViewColumn/columnHeader.jelly
+++ b/hudson-core/src/main/resources/hudson/views/ListViewColumn/columnHeader.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
  <j:jelly xmlns:j="jelly:core">
     <th>${it.columnCaption}</th>
  </j:jelly>

--- a/hudson-core/src/main/resources/hudson/views/ListViewColumn/config.jelly
+++ b/hudson-core/src/main/resources/hudson/views/ListViewColumn/config.jelly
@@ -23,4 +23,5 @@ THE SOFTWARE.
 -->
 
 <!-- Columns normally have nothing to configure. -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"/>

--- a/hudson-core/src/main/resources/hudson/views/StatusColumn/column.jelly
+++ b/hudson-core/src/main/resources/hudson/views/StatusColumn/column.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <t:ballColorTd it="${job.iconColor}" style="${indenter.getRelativeShift(job)}"/>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/views/StatusColumn/columnHeader.jelly
+++ b/hudson-core/src/main/resources/hudson/views/StatusColumn/columnHeader.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
-    <th tooltip="${%Status of the last build}">${h.nbspIndent(iconSize)}S</th>
+    <th tooltip="${%Status of the last build}"><j:out value="${h.nbspIndent(iconSize)}"/>S</th>
 </j:jelly>

--- a/hudson-core/src/main/resources/hudson/views/WeatherColumn/column.jelly
+++ b/hudson-core/src/main/resources/hudson/views/WeatherColumn/column.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <t:buildHealth td="true" style="${indenter.getRelativeShift(job)}"
       link="${jobBaseUrl}${job.shortUrl}lastBuild"/>

--- a/hudson-core/src/main/resources/hudson/views/WeatherColumn/columnHeader.jelly
+++ b/hudson-core/src/main/resources/hudson/views/WeatherColumn/columnHeader.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
  <j:jelly xmlns:j="jelly:core">
-    <th tooltip="${%Weather report showing aggregated status of recent builds}">${h.nbspIndent(iconSize)}W</th>
+    <th tooltip="${%Weather report showing aggregated status of recent builds}"><j:out value="${h.nbspIndent(iconSize)}"/>W</th>
  </j:jelly>

--- a/hudson-core/src/main/resources/hudson/widgets/BuildHistoryWidget/entries.jelly
+++ b/hudson-core/src/main/resources/hudson/widgets/BuildHistoryWidget/entries.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Render build histories.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <!-- pending build -->
   <j:set var="queuedItems" value="${it.queuedItems}" />

--- a/hudson-core/src/main/resources/hudson/widgets/HistoryWidget/ajaxBuildHistory.jelly
+++ b/hudson-core/src/main/resources/hudson/widgets/HistoryWidget/ajaxBuildHistory.jelly
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 <!--
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:ajax>
     <table>

--- a/hudson-core/src/main/resources/hudson/widgets/HistoryWidget/all.jelly
+++ b/hudson-core/src/main/resources/hudson/widgets/HistoryWidget/all.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Used by buildHistory.jelly to lazily fetch the complete build records.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout">
   <l:ajax>
     <j:set var="all" value="${true}"/>

--- a/hudson-core/src/main/resources/hudson/widgets/HistoryWidget/entries.jelly
+++ b/hudson-core/src/main/resources/hudson/widgets/HistoryWidget/entries.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Render build histories. 
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:set target="${it}" property="nextBuildNumberToFetch" value="${it.owner.nextBuildNumber}"/>
   <!-- build history -->

--- a/hudson-core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
+++ b/hudson-core/src/main/resources/hudson/widgets/HistoryWidget/entry.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Render a single build history entry indicated by ${build}
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:set var="link" value="${it.baseUrl}/${build.number}/" />
   <j:set var="transitive" value="${(it.firstTransientBuildKey!=null and (it.adapter.compare(build,it.firstTransientBuildKey) ge 0)) ? 'transitive' : null}" />
@@ -72,7 +73,7 @@ THE SOFTWARE.
     <tr class="${transitive}">
       <td></td>
       <td colspan="2" class="desc">
-        ${build.truncatedDescription}
+        <j:out value="${app.markupFormatter.translate(build.truncatedDescription)}" />
       </td>
     </tr>
   </j:if>

--- a/hudson-core/src/main/resources/lib/foo.jelly
+++ b/hudson-core/src/main/resources/lib/foo.jelly
@@ -22,4 +22,5 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <b>JELLY TAG FILE ${value}</b>

--- a/hudson-core/src/main/resources/lib/form/advanced.jelly
+++ b/hudson-core/src/main/resources/lib/form/advanced.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Expandable section that shows "advanced..." button by default.

--- a/hudson-core/src/main/resources/lib/form/block.jelly
+++ b/hudson-core/src/main/resources/lib/form/block.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Full-width space in the form table that can be filled with arbitrary HTML.

--- a/hudson-core/src/main/resources/lib/form/checkbox.jelly
+++ b/hudson-core/src/main/resources/lib/form/checkbox.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     &lt;input type="checkbox"> tag that takes true/false for @checked, which is more Jelly friendly.

--- a/hudson-core/src/main/resources/lib/form/combobox.jelly
+++ b/hudson-core/src/main/resources/lib/form/combobox.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- Tomcat doesn't like us using the attribute called 'class' -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Editable drop-down combo box that supports the data binding and AJAX updates.

--- a/hudson-core/src/main/resources/lib/form/description.jelly
+++ b/hudson-core/src/main/resources/lib/form/description.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Renders a row that shows description text below an input field.

--- a/hudson-core/src/main/resources/lib/form/descriptorList.jelly
+++ b/hudson-core/src/main/resources/lib/form/descriptorList.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Generate config pages from a list of Descriptors into a section.

--- a/hudson-core/src/main/resources/lib/form/descriptorRadioList.jelly
+++ b/hudson-core/src/main/resources/lib/form/descriptorRadioList.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Generate config pages from a list of Descriptors into a section.

--- a/hudson-core/src/main/resources/lib/form/dropdownDescriptorSelector.jelly
+++ b/hudson-core/src/main/resources/lib/form/dropdownDescriptorSelector.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Renders a single &lt;select> control for choosing a Describable.

--- a/hudson-core/src/main/resources/lib/form/dropdownList.jelly
+++ b/hudson-core/src/main/resources/lib/form/dropdownList.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
@@ -71,7 +72,7 @@ THE SOFTWARE.
 
     <j:if test="${!empty(attrs.description)}">
         <f:description>
-            ${description}
+            <j:out value="${description}"/>
         </f:description>
     </j:if>
     <j:if test="${attrs.help!=null}">

--- a/hudson-core/src/main/resources/lib/form/dropdownListBlock.jelly
+++ b/hudson-core/src/main/resources/lib/form/dropdownListBlock.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Foldable block expanded when the corresponding item is selected in the drop-down list.

--- a/hudson-core/src/main/resources/lib/form/editableComboBox.jelly
+++ b/hudson-core/src/main/resources/lib/form/editableComboBox.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- Tomcat doesn't like us using the attribute called 'class' -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Editable drop-down combo box. Deprecated as of 1.356. Use f:combobox and databinding instead.

--- a/hudson-core/src/main/resources/lib/form/editableComboBoxValue.jelly
+++ b/hudson-core/src/main/resources/lib/form/editableComboBoxValue.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <st:documentation>
     Used inside &lt;f:editableComboBox/> to specify one value of a combobox.

--- a/hudson-core/src/main/resources/lib/form/entry.jelly
+++ b/hudson-core/src/main/resources/lib/form/entry.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     An entry of the &lt;f:form>, which is one logical row (that consists of
@@ -72,7 +73,7 @@ THE SOFTWARE.
   <tr class="${attrs.isPropertyOverridden? 'modified': 'original'}">
     <td class="setting-leftspace"><st:nbsp/></td>
     <td class="setting-name">
-      ${attrs.title}
+      <j:out value="${attrs.title}" />
     </td>
     <td class="setting-main">
       <d:invokeBody />
@@ -87,7 +88,7 @@ THE SOFTWARE.
   <tr class="validation-error-area"><td colspan="2" /><td /></tr>
   <j:if test="${!empty(attrs.description)}">
     <f:description isPropertyOverridden="${attrs.isPropertyOverridden}">
-      ${description}
+      <j:out value="${description}"/>
     </f:description>
   </j:if>
   <j:if test="${attrs.help!=null}">

--- a/hudson-core/src/main/resources/lib/form/enum.jelly
+++ b/hudson-core/src/main/resources/lib/form/enum.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Binds an enum field to a &lt;select> element.

--- a/hudson-core/src/main/resources/lib/form/enumSet.jelly
+++ b/hudson-core/src/main/resources/lib/form/enumSet.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Binds a set of Enum to a list of checkboxes, each with the label taken from enum Enum.toString()

--- a/hudson-core/src/main/resources/lib/form/expandableTextbox.jelly
+++ b/hudson-core/src/main/resources/lib/form/expandableTextbox.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   TODO: support @checkUrl
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
   <st:documentation>
     single-line textbox that can be expanded into a multi-line textarea.

--- a/hudson-core/src/main/resources/lib/form/form.jelly
+++ b/hudson-core/src/main/resources/lib/form/form.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Outer-most tag of the entire form taglib, that generates &lt;form> element.

--- a/hudson-core/src/main/resources/lib/form/helpArea.jelly
+++ b/hudson-core/src/main/resources/lib/form/helpArea.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Place holder to lazy-load help text via AJAX.

--- a/hudson-core/src/main/resources/lib/form/hetero-list.jelly
+++ b/hudson-core/src/main/resources/lib/form/hetero-list.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
   <st:documentation>
     Outer most tag for creating a heterogeneous list, where the user can choose arbitrary number of

--- a/hudson-core/src/main/resources/lib/form/hetero-radio.jelly
+++ b/hudson-core/src/main/resources/lib/form/hetero-radio.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
   <st:documentation>
     Sibling of hetero-list, which only allows the user to pick one type from the list of descriptors and configure it.

--- a/hudson-core/src/main/resources/lib/form/invisibleEntry.jelly
+++ b/hudson-core/src/main/resources/lib/form/invisibleEntry.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Invisible &lt;f:entry> type. Useful for adding hidden field values.

--- a/hudson-core/src/main/resources/lib/form/nested.jelly
+++ b/hudson-core/src/main/resources/lib/form/nested.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Used to display indented nested portion of the form
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <st:documentation>
         <st:attribute name="isPropertyOverridden">

--- a/hudson-core/src/main/resources/lib/form/option.jelly
+++ b/hudson-core/src/main/resources/lib/form/option.jelly
@@ -38,6 +38,6 @@ THE SOFTWARE.
   </st:documentation>
   <!-- No escape/encode to avoid double-encoding if used in value attribute below -->
   <j:set var="optionBody" encode="false"><d:invokeBody escapeText="false"/></j:set>
-  <option value="${attrs.value!=null?attrs.value:optionBody}"
-          selected="${attrs.selected?'true':null}">${optionBody}</option>
+  <option value="${attrs.value!=null?attrs.value:h.xmlUnescape(optionBody)}"
+          selected="${attrs.selected?'true':null}"><j:out value="${optionBody}"/></option>
 </j:jelly>

--- a/hudson-core/src/main/resources/lib/form/optionalBlock.jelly
+++ b/hudson-core/src/main/resources/lib/form/optionalBlock.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Foldable block that can be expanded to show more controls by checking the checkbox.

--- a/hudson-core/src/main/resources/lib/form/optionalProperty.jelly
+++ b/hudson-core/src/main/resources/lib/form/optionalProperty.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Renders inline an optional single-value nested data-bound property of the current instance,

--- a/hudson-core/src/main/resources/lib/form/password.jelly
+++ b/hudson-core/src/main/resources/lib/form/password.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
   <st:documentation>
     Glorified &lt;input type="password">

--- a/hudson-core/src/main/resources/lib/form/prepareDatabinding.jelly
+++ b/hudson-core/src/main/resources/lib/form/prepareDatabinding.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
   <st:documentation>
     Modifies the 'attrs.field' of the parent to inherit @field from the enclosing &lt;f:entry>

--- a/hudson-core/src/main/resources/lib/form/property.jelly
+++ b/hudson-core/src/main/resources/lib/form/property.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Renders inline a single-value nested data-bound property of the current instance.

--- a/hudson-core/src/main/resources/lib/form/radio.jelly
+++ b/hudson-core/src/main/resources/lib/form/radio.jelly
@@ -27,5 +27,6 @@ THE SOFTWARE.
 
 	Note that safari doesn't support onchange.
 -->
+<?jelly escape-by-default='true'?>
 <input type="radio" name="${attrs.name}" onclick="${attrs.onclick}" id="${attrs.id}" value="${attrs.value}"
         checked="${attrs.checked?'true':null}"/>

--- a/hudson-core/src/main/resources/lib/form/radioBlock.jelly
+++ b/hudson-core/src/main/resources/lib/form/radioBlock.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Radio button with a label that hides additional controls.

--- a/hudson-core/src/main/resources/lib/form/readOnlyTextbox.jelly
+++ b/hudson-core/src/main/resources/lib/form/readOnlyTextbox.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form">
   <st:documentation>
     Generates an input field <tt>&lt;input type="text" ... /></tt> to be

--- a/hudson-core/src/main/resources/lib/form/repeatable.jelly
+++ b/hudson-core/src/main/resources/lib/form/repeatable.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation> <![CDATA[]
     Repeatable blocks used to present UI where the user can configure multiple entries

--- a/hudson-core/src/main/resources/lib/form/repeatableDeleteButton.jelly
+++ b/hudson-core/src/main/resources/lib/form/repeatableDeleteButton.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Delete button for the &lt;repeatable> tag.

--- a/hudson-core/src/main/resources/lib/form/repeatableProperty.jelly
+++ b/hudson-core/src/main/resources/lib/form/repeatableProperty.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation> <![CDATA[]
     Data-bound only version of <f:repeatable> that assumes the type pointed by the property is data-bound as well.

--- a/hudson-core/src/main/resources/lib/form/richtextarea.jelly
+++ b/hudson-core/src/main/resources/lib/form/richtextarea.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
   <st:documentation>
     Rich HTML editor from http://developer.yahoo.com/yui/editor/

--- a/hudson-core/src/main/resources/lib/form/rowSet.jelly
+++ b/hudson-core/src/main/resources/lib/form/rowSet.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Adds @nameRef to all table rows inside this tag, so that when the form is submitted,

--- a/hudson-core/src/main/resources/lib/form/section.jelly
+++ b/hudson-core/src/main/resources/lib/form/section.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <st:documentation>

--- a/hudson-core/src/main/resources/lib/form/select.jelly
+++ b/hudson-core/src/main/resources/lib/form/select.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- Tomcat doesn't like us using the attribute called 'class' -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Glorified &lt;select> control that supports the data binding and AJAX updates.

--- a/hudson-core/src/main/resources/lib/form/slave-mode.jelly
+++ b/hudson-core/src/main/resources/lib/form/slave-mode.jelly
@@ -28,6 +28,7 @@ THE SOFTWARE.
   @name : name of the <select> element
   @node : Node object
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="${%Usage}" help="/help/system-config/master-slave/usage.html">

--- a/hudson-core/src/main/resources/lib/form/submit.jelly
+++ b/hudson-core/src/main/resources/lib/form/submit.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:s="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form">
   <s:documentation>
     Submit button themed by YUI. This should be always

--- a/hudson-core/src/main/resources/lib/form/textarea.jelly
+++ b/hudson-core/src/main/resources/lib/form/textarea.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
   <st:documentation>
     &lt;textarea> tag on steroids.

--- a/hudson-core/src/main/resources/lib/form/textbox.jelly
+++ b/hudson-core/src/main/resources/lib/form/textbox.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form">
   <st:documentation>
     Generates an input field <tt>&lt;input type="text" ... /></tt> to be

--- a/hudson-core/src/main/resources/lib/form/validateButton.jelly
+++ b/hudson-core/src/main/resources/lib/form/validateButton.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
 
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     See

--- a/hudson-core/src/main/resources/lib/hudson/actions.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/actions.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Side panel for the build view.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:forEach var="action" items="${it.actions}">
     <j:if test="${action.iconFileName!=null}">

--- a/hudson-core/src/main/resources/lib/hudson/artifactList.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/artifactList.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Generates a listing of the build artifacts.
@@ -48,7 +49,7 @@ THE SOFTWARE.
             <ul>
               <j:forEach var="f" items="${artifacts}">
                 <li>
-                  <a href="${baseURL}artifact/${f.href}">${h.xmlEscape(f.displayPath)}</a>
+                  <a href="${baseURL}artifact/${f.href}">${f.displayPath}</a>
                   <st:nbsp/>
                   <a href="${baseURL}artifact/${f.href}/*fingerprint*/"><img src="${imagesURL}/16x16/fingerprint.gif" alt="[fingerprint]" /></a>
                 </li>

--- a/hudson-core/src/main/resources/lib/hudson/ballColorTd.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/ballColorTd.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Display the ball in a TD.

--- a/hudson-core/src/main/resources/lib/hudson/buildCaption.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/buildCaption.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
     displays a caption for build/externalRun.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<h1>
 	  <j:if test="${it.building}">

--- a/hudson-core/src/main/resources/lib/hudson/buildHealth.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/buildHealth.jelly
@@ -28,6 +28,7 @@ THE SOFTWARE.
   <%@ attribute name="td" required="false" type="java.lang.String" %>
   <%@ attribute name="link" required="false" type="java.lang.String" %>
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <j:set var="buildHealth" value="${job.buildHealth}"/>
     <j:if test="${td}"><j:set var="useTdElement" value="x"/></j:if>

--- a/hudson-core/src/main/resources/lib/hudson/buildLink.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/buildLink.jelly
@@ -31,6 +31,7 @@ THE SOFTWARE.
     number     build number to link to.
     href       Link target. If missing, the top page of the build.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="jobName_" value="${h.appendSpaceIfNotNull(jobName)}"/>
   <j:choose>

--- a/hudson-core/src/main/resources/lib/hudson/buildListTable.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/buildListTable.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <st:documentation>
     Creates a table of builds.

--- a/hudson-core/src/main/resources/lib/hudson/buildProgressBar.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/buildProgressBar.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Progress bar for a build in progress.

--- a/hudson-core/src/main/resources/lib/hudson/buildRangeLink.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/buildRangeLink.jelly
@@ -29,6 +29,7 @@ THE SOFTWARE.
 	<%@ attribute name="job" type="hudson.model.Job" required="true" %>
 -->
 <!-- it's hudson.model.Fingerprint.RangeSet but Tomcat can't seem to handler inner classes -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<j:forEach var="r" items="${range.ranges}">
 	  <j:choose>

--- a/hudson-core/src/main/resources/lib/hudson/buildStatusSummary.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/buildStatusSummary.jelly
@@ -22,14 +22,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
     <j:set var="summary" value="${build.buildStatusSummary}"/>
     <j:choose>
         <j:when test="${summary.isWorse}">
-          <font color='red'>${summary.message}</font>
+          <font color='red'><j:out value="${app.markupFormatter.translate(summary.message)}"/></font>
         </j:when>
         <j:otherwise>
-          ${summary.message}
+          <j:out value="${app.markupFormatter.translate(summary.message)}"/>
         </j:otherwise>
     </j:choose>
 </j:jelly>

--- a/hudson-core/src/main/resources/lib/hudson/cascadingDescriptorList.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/cascadingDescriptorList.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:f="/lib/form">
     <st:documentation>
         Generates config pages from a list of Descriptors into a section. Tag is based on cascading functionality.

--- a/hudson-core/src/main/resources/lib/hudson/editTypeIcon.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/editTypeIcon.jelly
@@ -26,6 +26,7 @@ THE SOFTWARE.
   Displays the edit type icon.
 	<%@ attribute name="type" type="hudson.scm.EditType" required="true" %>
 -->
+<?jelly escape-by-default='true'?>
 <img width="16" height="16"
   src="${imagesURL}/16x16/document_${type.name}.gif"
   title="${type.description}" alt="${type.description}" />

--- a/hudson-core/src/main/resources/lib/hudson/editableDescription.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/editableDescription.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Renders ${it.description} and then allow it to be editable in place,

--- a/hudson-core/src/main/resources/lib/hudson/help.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/help.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   (?) icon linked to the specified @href
 -->
+<?jelly escape-by-default='true'?>
 <a href="${href}">
   <img src="${imagesURL}/16x16/help.gif" alt="[help]"/>
 </a>

--- a/hudson-core/src/main/resources/lib/hudson/iconSize.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/iconSize.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <table style="width:100%">
     <tr>

--- a/hudson-core/src/main/resources/lib/hudson/jobLink.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/jobLink.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Generates a link to a job.

--- a/hudson-core/src/main/resources/lib/hudson/listScmBrowsers.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/listScmBrowsers.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     List browser SCMs

--- a/hudson-core/src/main/resources/lib/hudson/newFromList/form.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/newFromList/form.jelly
@@ -32,6 +32,7 @@ THE SOFTWARE.
     @copyNames   : options of names to choose from as the copy source. null to hide "copy" option
     @checkUrl    : form field validation url
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
   <j:set var="descriptors" value="${h.filterDescriptors(it,attrs.descriptors)}" />
 

--- a/hudson-core/src/main/resources/lib/hudson/node.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/node.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Displays a link to a node.

--- a/hudson-core/src/main/resources/lib/hudson/progressBar.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/progressBar.jelly
@@ -30,6 +30,7 @@ THE SOFTWARE.
     href : if set, the progress bar becomes a hyperlink
     red  : if set to non-null, the progress bar will be drawn in red, to indicate that the processing is likely stuck.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <table class="progress-bar ${attrs.red?'red':null}" id="${attrs.id}" tooltip="${attrs.tooltip}" href="${attrs.href}" style="${attrs.href!=null ? 'cursor:pointer' : null}">
     <j:choose>

--- a/hudson-core/src/main/resources/lib/hudson/progressiveText.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/progressiveText.jelly
@@ -32,6 +32,7 @@ THE SOFTWARE.
 	<%@attribute name="spinner" required="false" description="ID of the HTML element in which the spinner is displayed" %>
 	<%@attribute name="startOffset" required="false" description="Skip this many bytes rather than showing from start of data" %>
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<!--
 	  script code

--- a/hudson-core/src/main/resources/lib/hudson/project/build-permalink.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/build-permalink.jelly
@@ -31,6 +31,7 @@ THE SOFTWARE.
       Title of the link
 -->
         <!-- TODO: delete once batch-task plugin is updated. -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project">
   <j:set var="b" value="${it[property]}"/>
   <j:if test="${b!=null}">

--- a/hudson-core/src/main/resources/lib/hudson/project/config-blockWhenDownstreamBuilding.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/config-blockWhenDownstreamBuilding.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- Block build when downstream dependency is building -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="blockBuildWhenDownstreamBuildingProperty"
          value="${cu.getBooleanProjectProperty(it, it.BLOCK_BUILD_WHEN_DOWNSTREAM_BUILDING_PROPERTY_NAME)}"/>

--- a/hudson-core/src/main/resources/lib/hudson/project/config-blockWhenUpstreamBuilding.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/config-blockWhenUpstreamBuilding.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- Block build when upstream dependency is building -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="blockBuildWhenUpstreamBuildingProperty"
          value="${cu.getBooleanProjectProperty(it, it.BLOCK_BUILD_WHEN_UPSTREAM_BUILDING_PROPERTY_NAME)}"/>

--- a/hudson-core/src/main/resources/lib/hudson/project/config-buildWrappers.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/config-buildWrappers.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Build wrapper config pane
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project">
     <t:cascadingDescriptorList title="${%Build Environment}" descriptors="${h.getBuildWrapperDescriptors(it)}"/>
 </j:jelly>

--- a/hudson-core/src/main/resources/lib/hudson/project/config-builders.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/config-builders.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Builder config pane
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project">
   <j:set var="buildersProperty" value="${cu.getDescribableListProjectProperty(it, it.BUILDERS_PROPERTY_NAME)}"/>
   <j:set var="builders" value="${buildersProperty.getValue()}"/>

--- a/hudson-core/src/main/resources/lib/hudson/project/config-cleanWorkspace.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/config-cleanWorkspace.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- clean workspace -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="cleanWorkspaceRequiredProperty" value="${cu.getBooleanProjectProperty(it, it.CLEAN_WORKSPACE_REQUIRED_PROPERTY_NAME)}"/>
   <j:set var="cleanWorkspaceRequired" value="${cleanWorkspaceRequiredProperty.getValue()}"/>

--- a/hudson-core/src/main/resources/lib/hudson/project/config-customWorkspace.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/config-customWorkspace.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- custom workspace -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="customWorkspaceProperty" value="${cu.getStringProjectProperty(it, it.CUSTOM_WORKSPACE_PROPERTY_NAME)}"/>
   <j:set var="customWorkspace" value="${customWorkspaceProperty.getValue()}"/>

--- a/hudson-core/src/main/resources/lib/hudson/project/config-disableBuild.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/config-disableBuild.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Configuration entry for disabling builds
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:optionalBlock name="disable" title="${%Disable Build} (${%No new builds will be executed until the project is re-enabled.})" checked="${it.disabled}"
                    help="/help/project-config/disable.html" />

--- a/hudson-core/src/main/resources/lib/hudson/project/config-publishers.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/config-publishers.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Publisher config pane
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project">
     <t:cascadingDescriptorList title="${%Post-build Actions}" descriptors="${h.getPublisherDescriptors(it)}"/>
 </j:jelly>

--- a/hudson-core/src/main/resources/lib/hudson/project/config-quietPeriod.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/config-quietPeriod.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- custom quiet period -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="quietPeriodProperty" value="${cu.getIntegerProjectProperty(it, it.QUIET_PERIOD_PROPERTY_NAME)}"/>
   <j:set var="quietPeriod" value="${quietPeriodProperty.getValue()}"/>

--- a/hudson-core/src/main/resources/lib/hudson/project/config-retryCount.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/config-retryCount.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- custom retry count -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="scmCheckoutRetryCountProperty" value="${cu.getIntegerProjectProperty(it, it.SCM_CHECKOUT_RETRY_COUNT_PROPERTY_NAME)}"/>
   <j:set var="scmCheckoutRetryCount" value="${scmCheckoutRetryCountProperty.getValue()}"/>

--- a/hudson-core/src/main/resources/lib/hudson/project/config-scm.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/config-scm.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- SCM config pane -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <j:set var="scmProperty" value="${cu.getScmProjectProperty(it, it.SCM_PROPERTY_NAME)}"/>

--- a/hudson-core/src/main/resources/lib/hudson/project/config-trigger.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/config-trigger.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Configure build triggers
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <!-- build triggers config pane -->
   <j:invokeStatic var="triggers" className="hudson.triggers.Trigger" method="for_">

--- a/hudson-core/src/main/resources/lib/hudson/project/config-upstream-pseudo-trigger.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/config-upstream-pseudo-trigger.jelly
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
   "it" is assumed to be a Project object.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <!-- pseudo-trigger to list upstream projects. -->
   <j:set var="up" value="${it.buildTriggerUpstreamProjects}" />

--- a/hudson-core/src/main/resources/lib/hudson/project/matrix.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/matrix.jelly
@@ -28,6 +28,7 @@ THE SOFTWARE.
 
   Used by Matrix* classes
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
   <st:documentation>
     Generate configuration matrix and invoke body with 'p' as the instance of T

--- a/hudson-core/src/main/resources/lib/hudson/project/projectActionFloatingBox.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/projectActionFloatingBox.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Used in the index page to show floating boxes contributed from project actions.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div style="float:right">
     <j:forEach var="a" items="${it.actions}">

--- a/hudson-core/src/main/resources/lib/hudson/project/upstream-downstream.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/project/upstream-downstream.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Display upstream/downstream projects
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:local="local">
   <d:taglib uri="local">
     <d:tag name="relationship">

--- a/hudson-core/src/main/resources/lib/hudson/projectView.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/projectView.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>

--- a/hudson-core/src/main/resources/lib/hudson/projectViewNested.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/projectViewNested.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Renders the nest view in <projectView />
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <tr>

--- a/hudson-core/src/main/resources/lib/hudson/projectViewRow.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/projectViewRow.jelly
@@ -28,6 +28,7 @@ THE SOFTWARE.
     @job : job to draw
     @indenter
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="lsBuild" value="${job.lastSuccessfulBuild}"/>

--- a/hudson-core/src/main/resources/lib/hudson/propertyTable.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/propertyTable.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Dispaly sortable table of properties.
@@ -42,7 +43,7 @@ THE SOFTWARE.
           <j:invokeStatic var="escapedValue" className="hudson.Util" method="escapeString">
             <j:arg value="${e.value}" />
           </j:invokeStatic>
-          ${escapedValue}
+          <j:out value="${escapedValue}"/>
         </td>
       </tr>
     </j:forEach>

--- a/hudson-core/src/main/resources/lib/hudson/queue.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/queue.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Displays the build queue as &lt;l:pane>

--- a/hudson-core/src/main/resources/lib/hudson/rssBar-with-iconSize.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/rssBar-with-iconSize.jelly
@@ -23,6 +23,7 @@ THE SOFTWARE.
 -->
 
 <!-- Deprecated since 1.345: use <t:iconSize><t:rssBar/></t:iconSize> -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
   <t:iconSize><t:rssBar/></t:iconSize>
 </j:jelly>

--- a/hudson-core/src/main/resources/lib/hudson/rssBar.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/rssBar.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div align="right" style="margin:1em">
     <a href="${rootURL}/legend">${%Legend}</a>

--- a/hudson-core/src/main/resources/lib/hudson/scriptConsole.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/scriptConsole.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Called from doScript() to display the execution result and the form.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true">
     <st:include page="sidepanel.jelly" />

--- a/hudson-core/src/main/resources/lib/hudson/setIconSize.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/setIconSize.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   read icon size from a cookie and set it up
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:x="jelly:xml" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set scope="parent" var="iconSize" value="${h.getCookie(request,'iconSize','32x32')}" />
   <!--

--- a/hudson-core/src/main/resources/lib/hudson/summary.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/summary.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Displays a link with a large icon. Used in the project top page.

--- a/hudson-core/src/main/resources/lib/hudson/test-result.jelly
+++ b/hudson-core/src/main/resources/lib/hudson/test-result.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <st:documentation>
     Evaluates to a sstring that reports the test result number in text, like "(5 failures / +3)".

--- a/hudson-core/src/main/resources/lib/layout/ajax.jelly
+++ b/hudson-core/src/main/resources/lib/layout/ajax.jelly
@@ -32,6 +32,7 @@ THE SOFTWARE.
 
   See MatrixProject/index.jelly and ajaxMatrix.jelly for how to use this tag.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form" xmlns:p="/lib/hudson/project">
   <j:choose>
     <j:when test="${rootURL!=null}">

--- a/hudson-core/src/main/resources/lib/layout/expandButton.jelly
+++ b/hudson-core/src/main/resources/lib/layout/expandButton.jelly
@@ -30,6 +30,7 @@ THE SOFTWARE.
   Attributes:
   @title :   title of the button. required.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div class="advancedLink">
     <input type="button" value="${attrs.title}" class="expandButton" />

--- a/hudson-core/src/main/resources/lib/layout/hasPermission.jelly
+++ b/hudson-core/src/main/resources/lib/layout/hasPermission.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:st="jelly:stapler">
   <st:documentation>
     Renders the body only if the current user has the specified permission

--- a/hudson-core/src/main/resources/lib/layout/header.jelly
+++ b/hudson-core/src/main/resources/lib/layout/header.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:s="jelly:stapler" xmlns:d="jelly:define">
   <s:documentation>
     Header portion of the HTML page, that gets rendered into the &lt;head> tag.

--- a/hudson-core/src/main/resources/lib/layout/isAdmin.jelly
+++ b/hudson-core/src/main/resources/lib/layout/isAdmin.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:s="jelly:stapler">
   <j:if test="${h.hasPermission(app.ADMINISTER)}">
     <d:invokeBody />

--- a/hudson-core/src/main/resources/lib/layout/isAdminOrTest.jelly
+++ b/hudson-core/src/main/resources/lib/layout/isAdminOrTest.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
 <%@ attribute name="test" required="true" type="java.lang.Boolean" %>
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:s="jelly:stapler">
     <j:choose>
         <j:when test="${!test &amp;&amp; app.useSecurity}">

--- a/hudson-core/src/main/resources/lib/layout/jobDeleteForm.jelly
+++ b/hudson-core/src/main/resources/lib/layout/jobDeleteForm.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <script type="text/javascript">
          function onDeleteClick() {

--- a/hudson-core/src/main/resources/lib/layout/main-panel.jelly
+++ b/hudson-core/src/main/resources/lib/layout/main-panel.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
   <st:documentation>
     Generates the body as the main content part of a Hudson page.

--- a/hudson-core/src/main/resources/lib/layout/pane.jelly
+++ b/hudson-core/src/main/resources/lib/layout/pane.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:st="jelly:stapler">
   <st:documentation>
     Used in the &lt;l:side-panel> to draw a box with a title.
@@ -43,7 +44,7 @@ THE SOFTWARE.
   </st:documentation>
   <table class="pane" id="${attrs.id}">
     <tr><td class="pane-header" colspan="${width}">
-      ${title}
+      <j:out value="${title}"/>
     </td></tr>
     <d:invokeBody />
   </table>

--- a/hudson-core/src/main/resources/lib/layout/rightspace.jelly
+++ b/hudson-core/src/main/resources/lib/layout/rightspace.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:st="jelly:stapler">
   <st:documentation>
     Creates a space for the right-hand side of the page.

--- a/hudson-core/src/main/resources/lib/layout/searchPopup.jelly
+++ b/hudson-core/src/main/resources/lib/layout/searchPopup.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:i="jelly:fmt">
     <script src="${resURL}/scripts/popup-dialog.js" type="text/javascript" />
     <script type="text/javascript">

--- a/hudson-core/src/main/resources/lib/layout/side-panel.jelly
+++ b/hudson-core/src/main/resources/lib/layout/side-panel.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:s="jelly:stapler" xmlns:d="jelly:define">
   <j:if test="${mode=='side-panel'}">
     <d:invokeBody />

--- a/hudson-core/src/main/resources/lib/layout/tab.jelly
+++ b/hudson-core/src/main/resources/lib/layout/tab.jelly
@@ -28,6 +28,7 @@ THE SOFTWARE.
 <%@ attribute name="active" required="true" type="java.lang.Boolean" %>
 <%@ attribute name="title" required="false" type="java.lang.String" %>
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core">
   <j:choose>
     <j:when test="${tabPass=='pass1'}">

--- a/hudson-core/src/main/resources/lib/layout/tabBar.jelly
+++ b/hudson-core/src/main/resources/lib/layout/tabBar.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define" xmlns:st="jelly:stapler">
   <table cellpadding="0" cellspacing="0" id="viewList">
     <j:set var="tab" value="${tabs}" />

--- a/hudson-core/src/main/resources/lib/layout/task.jelly
+++ b/hudson-core/src/main/resources/lib/layout/task.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
   <st:documentation>
     This tag inside &lt;l:tasks> tag renders the left navigation bar of Hudson.

--- a/hudson-core/src/main/resources/lib/layout/taskWithDialog.jelly
+++ b/hudson-core/src/main/resources/lib/layout/taskWithDialog.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define">
   <st:documentation>
     This tag inside &lt;l:tasks> tag renders the left navigation bar of Hudson.

--- a/hudson-core/src/main/resources/lib/layout/tasks.jelly
+++ b/hudson-core/src/main/resources/lib/layout/tasks.jelly
@@ -32,6 +32,7 @@ THE SOFTWARE.
       ...
     </l:tasks>
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define">
 	<div id="tasks">
 	  <d:invokeBody />

--- a/hudson-core/src/main/resources/lib/layout/yui.jelly
+++ b/hudson-core/src/main/resources/lib/layout/yui.jelly
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <st:documentation>
     Load Yahoo UI module.

--- a/hudson-core/src/main/resources/lib/test/bar.jelly
+++ b/hudson-core/src/main/resources/lib/test/bar.jelly
@@ -33,6 +33,7 @@ THE SOFTWARE.
 
   both objects need to have .failCount and .totalCount properties
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <div>
     <j:choose>

--- a/hudson-test-framework/src/main/resources/org/jvnet/hudson/test/CaptureEnvironmentBuilder/config.jelly
+++ b/hudson-test-framework/src/main/resources/org/jvnet/hudson/test/CaptureEnvironmentBuilder/config.jelly
@@ -22,4 +22,5 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" />

--- a/hudson-test-framework/src/main/resources/org/jvnet/hudson/test/ComputerConnectorTester/configure.jelly
+++ b/hudson-test-framework/src/main/resources/org/jvnet/hudson/test/ComputerConnectorTester/configure.jelly
@@ -25,6 +25,7 @@ THE SOFTWARE.
 <!--
   Config page
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout norefresh="true" title="Configuration">

--- a/hudson-test-framework/src/main/resources/org/jvnet/hudson/test/FailureBuilder/config.jelly
+++ b/hudson-test-framework/src/main/resources/org/jvnet/hudson/test/FailureBuilder/config.jelly
@@ -22,4 +22,5 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" />

--- a/hudson-test-framework/src/main/resources/org/jvnet/hudson/test/MockBuilder/config.jelly
+++ b/hudson-test-framework/src/main/resources/org/jvnet/hudson/test/MockBuilder/config.jelly
@@ -22,4 +22,5 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" />

--- a/hudson-test-framework/src/main/resources/org/jvnet/hudson/test/SleepBuilder/config.jelly
+++ b/hudson-test-framework/src/main/resources/org/jvnet/hudson/test/SleepBuilder/config.jelly
@@ -22,4 +22,5 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" />

--- a/hudson-test-framework/src/main/resources/org/jvnet/hudson/test/UnstableBuilder/config.jelly
+++ b/hudson-test-framework/src/main/resources/org/jvnet/hudson/test/UnstableBuilder/config.jelly
@@ -22,4 +22,5 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" />


### PR DESCRIPTION
Also applies markup formatting to various user-supplied content.
