### PR TITLE
Avoid accidental unlink of cascading parent when security is enabled

### DIFF
--- a/hudson-core/src/main/java/hudson/util/CascadingUtil.java
+++ b/hudson-core/src/main/java/hudson/util/CascadingUtil.java
@@ -39,6 +39,7 @@ import hudson.triggers.TriggerDescriptor;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -402,6 +403,10 @@ public class CascadingUtil {
      */
     @SuppressWarnings("unchecked")
     public static <T extends Item> List<Job> getCascadingParents(Class<T> type, Job currentJob) {
+        Job currentParent = currentJob.getCascadingProject();
+        if (type.isInstance(currentParent) && !currentParent.hasPermission(Item.READ)) {
+            return Collections.EMPTY_LIST; // user can't see parent so don't let them change it
+        }
         List<T> allItems = Hudson.getInstance().getAllItems(type);
         List<Job> result = new ArrayList<Job>(allItems.size());
         for (T item : allItems) {

--- a/hudson-core/src/main/java/hudson/util/CascadingUtil.java
+++ b/hudson-core/src/main/java/hudson/util/CascadingUtil.java
@@ -288,7 +288,7 @@ public class CascadingUtil {
             }
             for (String childName : cascadingChildren) {
                 Job job = Functions.getItemByName(Hudson.getInstance().getAllItems(Job.class), childName);
-                if (hasCyclicCascadingLink(cascadingCandidate, job.getCascadingChildrenNames())) {
+                if (null != job && hasCyclicCascadingLink(cascadingCandidate, job.getCascadingChildrenNames())) {
                     return true;
                 }
             }
@@ -308,9 +308,11 @@ public class CascadingUtil {
         throws IOException {
         if (null != cascadingProject && null != projectToUnlink) {
             Job job = Functions.getItemByName(Hudson.getInstance().getAllItems(Job.class), projectToUnlink);
-            Set<String> set = new HashSet<String>(job.getCascadingChildrenNames());
-            set.add(projectToUnlink);
-            return unlinkProjectFromCascadingParents(cascadingProject, set);
+            if (null != job) {
+                Set<String> set = new HashSet<String>(job.getCascadingChildrenNames());
+                set.add(projectToUnlink);
+                return unlinkProjectFromCascadingParents(cascadingProject, set);
+            }
         }
         return false;
     }

--- a/hudson-core/src/main/resources/hudson/model/Job/configure.jelly
+++ b/hudson-core/src/main/resources/hudson/model/Job/configure.jelly
@@ -42,16 +42,23 @@ THE SOFTWARE.
           </f:entry>
         </j:if>
         <j:set var="cascadingCandidates" value="${cu.getCascadingParents(it.class, it)}"/>
-        <j:if test="${cascadingCandidates.size() gt 0}">
-          <f:entry title="${%cascadingProjectName}" help="/help/project-config/cascadingProject.html">
-            <select class="setting-input" name="cascadingProjectName">
-              <f:option value="">${%emptyCascadingProjectName}</f:option>
-              <j:forEach var="job" items="${cascadingCandidates}">
-                <f:option selected="${job.name==it.cascadingProjectName}" value="${job.name}">${job.name}</f:option>
-              </j:forEach>
-            </select>
-          </f:entry>
-        </j:if>
+        <j:choose>
+          <j:when test="${cascadingCandidates.size() gt 0}">
+            <f:entry title="${%cascadingProjectName}" help="/help/project-config/cascadingProject.html">
+              <select class="setting-input" name="cascadingProjectName">
+                <f:option value="">${%emptyCascadingProjectName}</f:option>
+                <j:forEach var="job" items="${cascadingCandidates}">
+                  <f:option selected="${job.name==it.cascadingProjectName}" value="${job.name}">${job.name}</f:option>
+                </j:forEach>
+              </select>
+            </f:entry>
+          </j:when>
+          <j:otherwise>
+            <f:invisibleEntry>
+              <input type="hidden" name="cascadingProjectName" value="${it.cascadingProjectName}" />
+            </f:invisibleEntry>
+          </j:otherwise>
+        </j:choose>
         <f:entry title="${%Description}" help="/help/project-config/description.html">
           <f:textarea name="description" value="${it.description}"/>
         </f:entry>


### PR DESCRIPTION
1. Create new job C using admin account and cascade from an existing job P
2. Save C and give configure (and read) permission to user who cannot see P
3. Login as that user and try to update C, for example by adding a build step

You get following exception:

```
java.lang.NullPointerException
hudson.util.CascadingUtil.unlinkProjectFromCascadingParents(CascadingUtil.java:310)
hudson.model.Job.clearCascadingProject(Job.java:1820)
hudson.model.Job.setCascadingProjectName(Job.java:1769)
hudson.model.Job.submit(Job.java:1433)
```

This is because when jelly rendered the project configuration it called getCascadingParents, which returned a list that did not contain the current parent because it was not visible to the current user.

The solution contains two fixes - one avoids NPEs when the current parent is unavailable, the other uses a hidden entry to keep the current parent when there are no visible alternatives. Note getCascadingParents is also modified to return an empty list for the specific situation where the project has a valid parent, but it is not visible to the current user. In this scenario it does not make sense to give the user an option to change or remove the parent, as they would not be able to change it back. Instead we assume that they should be unaware of the actual parent, and therefore return the empty list which then triggers the hidden entry.
